### PR TITLE
enforce duration constraints for interview types and coach interview services follow 30min block

### DIFF
--- a/Intervu.API.Test/ApiTests/InterviewTypeController/AddInterviewType.cs
+++ b/Intervu.API.Test/ApiTests/InterviewTypeController/AddInterviewType.cs
@@ -66,7 +66,7 @@ namespace Intervu.API.Test.ApiTests.InterviewTypeController
                 Id = Guid.NewGuid(),
                 Name = interviewTypeName,
                 Description = "Another description",
-                SuggestedDurationMinutes = 45,
+                SuggestedDurationMinutes = 60,
                 MinPrice = 750,
                 MaxPrice = 1500
             };
@@ -98,6 +98,25 @@ namespace Intervu.API.Test.ApiTests.InterviewTypeController
 
             await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, createResponse.StatusCode, "Status code is 400 Bad Request for invalid data");
             await AssertHelper.AssertFalse(createPayload.Success, "Invalid data interview type creation should fail");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewType")]
+        public async Task AddInterviewType_DurationNotMultipleOf30_ReturnsBadRequest()
+        {
+            var createDto = new InterviewTypeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Invalid Duration {Guid.NewGuid().ToString().Substring(0, 8)}",
+                Description = "Duration validation test",
+                SuggestedDurationMinutes = 50,
+                MinPrice = 1000,
+                MaxPrice = 2000
+            };
+
+            var createResponse = await _api.PostAsync("/api/v1/interviewtype", createDto, logBody: true);
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, createResponse.StatusCode, "Non-multiple duration returns 400 Bad Request");
         }
 
         [Fact]

--- a/Intervu.API.Test/ApiTests/InterviewTypeController/UpdateInterviewType.cs
+++ b/Intervu.API.Test/ApiTests/InterviewTypeController/UpdateInterviewType.cs
@@ -38,7 +38,7 @@ namespace Intervu.API.Test.ApiTests.InterviewTypeController
                 Id = typeId,
                 Name = "Updated Type",
                 Description = "Updated description",
-                SuggestedDurationMinutes = 45,
+                SuggestedDurationMinutes = 60,
                 MinPrice = 1200,
                 MaxPrice = 4800
             }, logBody: true);
@@ -62,7 +62,7 @@ namespace Intervu.API.Test.ApiTests.InterviewTypeController
                 Id = missingTypeId,
                 Name = "Updated Type",
                 Description = "Updated description",
-                SuggestedDurationMinutes = 45,
+                SuggestedDurationMinutes = 60,
                 MinPrice = 1200,
                 MaxPrice = 4800
             }, logBody: true);
@@ -99,6 +99,35 @@ namespace Intervu.API.Test.ApiTests.InterviewTypeController
             var updatePayload = await _api.LogDeserializeJson<JsonElement>(updateResponse, logBody: true);
             await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, updateResponse.StatusCode, "Status code is 400 Bad Request for invalid update data");
             await AssertHelper.AssertFalse(updatePayload.Success, "Invalid data update should fail");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewType")]
+        public async Task UpdateInterviewType_DurationNotMultipleOf30_ReturnsBadRequest()
+        {
+            var typeId = Guid.NewGuid();
+            await _api.PostAsync("/api/v1/interviewtype", new InterviewTypeDto
+            {
+                Id = typeId,
+                Name = $"Valid Type {Guid.NewGuid().ToString().Substring(0, 8)}",
+                Description = "Description",
+                SuggestedDurationMinutes = 60,
+                MinPrice = 1000,
+                MaxPrice = 5000
+            });
+
+            var updateResponse = await _api.PutAsync($"/api/v1/interviewtype/{typeId}", new InterviewTypeDto
+            {
+                Id = typeId,
+                Name = "Updated Type",
+                Description = "Updated description",
+                SuggestedDurationMinutes = 50,
+                MinPrice = 1200,
+                MaxPrice = 4800
+            }, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, updateResponse.StatusCode, "Non-multiple duration returns 400 Bad Request");
         }
 
         [Fact]

--- a/Intervu.API.Test/ApiTests/Interviewer/CoachInterviewServiceControllerTests.cs
+++ b/Intervu.API.Test/ApiTests/Interviewer/CoachInterviewServiceControllerTests.cs
@@ -74,7 +74,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _cvInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
 
             // Act
@@ -154,7 +154,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _cvInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
             var createResponse = await _api.PostAsync("/api/v1/coach-interview-services", createDto, jwtToken: token);
             var createResult = await _api.LogDeserializeJson<CoachInterviewServiceDto>(createResponse);
@@ -163,7 +163,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             var updateDto = new UpdateCoachInterviewServiceDto
             {
                 Price = 1800,
-                DurationMinutes = 50
+                DurationMinutes = 90
             };
 
             // Act
@@ -189,7 +189,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _cvInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
             var createResponse = await _api.PostAsync("/api/v1/coach-interview-services", createDto, jwtToken: token);
             var createResult = await _api.LogDeserializeJson<CoachInterviewServiceDto>(createResponse);
@@ -312,7 +312,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _cvInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
 
             // Act
@@ -333,7 +333,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _cvInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
 
             // Act
@@ -354,7 +354,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _nonExistentInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
 
             // Act
@@ -375,7 +375,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             var updateDto = new UpdateCoachInterviewServiceDto
             {
                 Price = 1800,
-                DurationMinutes = 50
+                DurationMinutes = 60
             };
 
             // Act
@@ -398,7 +398,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _cvInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
             var createResponse = await _api.PostAsync("/api/v1/coach-interview-services", createDto, jwtToken: coach1Token);
             var createResult = await _api.LogDeserializeJson<CoachInterviewServiceDto>(createResponse);
@@ -446,7 +446,7 @@ namespace Intervu.API.Test.ApiTests.Interviewer
             {
                 InterviewTypeId = _cvInterviewTypeId,
                 Price = 1500,
-                DurationMinutes = 45
+                DurationMinutes = 60
             };
             var createResponse = await _api.PostAsync("/api/v1/coach-interview-services", createDto, jwtToken: coach1Token);
             var createResult = await _api.LogDeserializeJson<CoachInterviewServiceDto>(createResponse);

--- a/Intervu.Application/DTOs/CoachInterviewService/CreateCoachInterviewServiceDto.cs
+++ b/Intervu.Application/DTOs/CoachInterviewService/CreateCoachInterviewServiceDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Intervu.Domain.Abstractions.Validation;
 
 namespace Intervu.Application.DTOs.CoachInterviewService
 {
@@ -22,6 +23,7 @@ namespace Intervu.Application.DTOs.CoachInterviewService
         /// </summary>
         [Required]
         [Range(15, 300)]
+        [MultipleOf(30, ErrorMessage = "Duration must be a multiple of 30 minutes.")]
         public int DurationMinutes { get; set; }
     }
 }

--- a/Intervu.Application/DTOs/CoachInterviewService/UpdateCoachInterviewServiceDto.cs
+++ b/Intervu.Application/DTOs/CoachInterviewService/UpdateCoachInterviewServiceDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Intervu.Domain.Abstractions.Validation;
 
 namespace Intervu.Application.DTOs.CoachInterviewService
 {
@@ -19,6 +20,7 @@ namespace Intervu.Application.DTOs.CoachInterviewService
         /// </summary>
         [Required]
         [Range(15, 300)]
+        [MultipleOf(30, ErrorMessage = "Duration must be a multiple of 30 minutes.")]
         public int DurationMinutes { get; set; }
     }
 }

--- a/Intervu.Application/DTOs/InterviewType/InterviewTypeDto.cs
+++ b/Intervu.Application/DTOs/InterviewType/InterviewTypeDto.cs
@@ -1,5 +1,6 @@
 ﻿using Intervu.Domain.Entities;
 using Intervu.Domain.Entities.Constants;
+using Intervu.Domain.Abstractions.Validation;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -27,6 +28,7 @@ namespace Intervu.Application.DTOs.InterviewType
         public int MaxPrice { get; set; }
 
         [Range(15, 300)]
+        [MultipleOf(30, ErrorMessage = "Suggested duration must be a multiple of 30 minutes.")]
         public int SuggestedDurationMinutes { get; set; }
 
         public List<EvaluationItem>? EvaluationStructure { get; set; }

--- a/Intervu.Application/UseCases/CoachInterviewService/CreateCoachInterviewService.cs
+++ b/Intervu.Application/UseCases/CoachInterviewService/CreateCoachInterviewService.cs
@@ -28,6 +28,11 @@ namespace Intervu.Application.UseCases.CoachInterviewService
 
         public async Task<CoachInterviewServiceDto> ExecuteAsync(Guid coachId, CreateCoachInterviewServiceDto dto)
         {
+            if (dto.DurationMinutes % 30 != 0)
+            {
+                throw new BadRequestException("Duration must be a multiple of 30 minutes.");
+            }
+
             var coach = await _coachRepo.GetProfileByIdAsync(coachId)
                 ?? throw new NotFoundException("Coach profile not found");
 

--- a/Intervu.Application/UseCases/CoachInterviewService/UpdateCoachInterviewService.cs
+++ b/Intervu.Application/UseCases/CoachInterviewService/UpdateCoachInterviewService.cs
@@ -24,6 +24,11 @@ namespace Intervu.Application.UseCases.CoachInterviewService
 
         public async Task<CoachInterviewServiceDto> ExecuteAsync(Guid coachId, Guid serviceId, UpdateCoachInterviewServiceDto dto)
         {
+            if (dto.DurationMinutes % 30 != 0)
+            {
+                throw new BadRequestException("Duration must be a multiple of 30 minutes.");
+            }
+
             var service = await _serviceRepo.GetByIdWithDetailsAsync(serviceId)
                 ?? throw new NotFoundException("Coach interview service not found");
 

--- a/Intervu.Application/UseCases/InterviewType/CreateInterviewType.cs
+++ b/Intervu.Application/UseCases/InterviewType/CreateInterviewType.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Intervu.Application.DTOs.InterviewType;
+using Intervu.Application.Exceptions;
 using Intervu.Application.Interfaces.UseCases.InterviewType;
 using Intervu.Domain.Repositories;
 using System;
@@ -23,6 +24,11 @@ namespace Intervu.Application.UseCases.InterviewType
 
         public async Task ExecuteAsync(InterviewTypeDto interviewTypeDto)
         {
+            if (interviewTypeDto.SuggestedDurationMinutes % 30 != 0)
+            {
+                throw new BadRequestException("Suggested duration must be a multiple of 30 minutes.");
+            }
+
             Domain.Entities.InterviewType interviewType = _mapper.Map<Domain.Entities.InterviewType>(interviewTypeDto);
             await _repo.AddAsync(interviewType);
             await _repo.SaveChangesAsync();

--- a/Intervu.Application/UseCases/InterviewType/UpdateInterviewType.cs
+++ b/Intervu.Application/UseCases/InterviewType/UpdateInterviewType.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Intervu.Application.DTOs.InterviewType;
+using Intervu.Application.Exceptions;
 using Intervu.Application.Interfaces.UseCases.InterviewType;
 using Intervu.Domain.Repositories;
 using System;
@@ -25,6 +26,11 @@ namespace Intervu.Application.UseCases.InterviewType
         {
             if (id == Guid.Empty)
                 throw new ArgumentException("Type ID must be a valid GUID");
+
+            if (interviewTypeDto.SuggestedDurationMinutes % 30 != 0)
+            {
+                throw new BadRequestException("Suggested duration must be a multiple of 30 minutes.");
+            }
 
             var interviewTypeToUpdate = await _repo.GetByIdAsync(id);
             

--- a/Intervu.Domain/Abstractions/Validation/MultipleOfAttribute.cs
+++ b/Intervu.Domain/Abstractions/Validation/MultipleOfAttribute.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Intervu.Domain.Abstractions.Validation
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+    public sealed class MultipleOfAttribute : ValidationAttribute
+    {
+        public int Divisor { get; }
+
+        public MultipleOfAttribute(int divisor)
+        {
+            if (divisor <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(divisor), "Divisor must be greater than zero.");
+            }
+
+            Divisor = divisor;
+            ErrorMessage = "The field {0} must be a multiple of {1}.";
+        }
+
+        public override bool IsValid(object? value)
+        {
+            if (value is null)
+            {
+                return true;
+            }
+
+            if (value is int intValue)
+            {
+                return intValue % Divisor == 0;
+            }
+
+            return false;
+        }
+
+        public override string FormatErrorMessage(string name)
+        {
+            return string.Format(ErrorMessageString, name, Divisor);
+        }
+    }
+}

--- a/Intervu.Domain/Entities/CoachInterviewService.cs
+++ b/Intervu.Domain/Entities/CoachInterviewService.cs
@@ -1,4 +1,6 @@
 using Intervu.Domain.Abstractions.Entity;
+using Intervu.Domain.Abstractions.Validation;
+using System.ComponentModel.DataAnnotations;
 
 namespace Intervu.Domain.Entities
 {
@@ -21,6 +23,8 @@ namespace Intervu.Domain.Entities
         /// <summary>
         /// Coach's custom duration in minutes
         /// </summary>
+        [Range(15, 300)]
+        [MultipleOf(30, ErrorMessage = "Duration must be a multiple of 30 minutes.")]
         public int DurationMinutes { get; set; }
 
         // Navigation

--- a/Intervu.Domain/Entities/InterviewType.cs
+++ b/Intervu.Domain/Entities/InterviewType.cs
@@ -1,4 +1,5 @@
 ﻿using Intervu.Domain.Abstractions.Entity;
+using Intervu.Domain.Abstractions.Validation;
 using Intervu.Domain.Entities.Constants;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -23,6 +24,7 @@ namespace Intervu.Domain.Entities
         public int MaxPrice { get; set; }
 
         [Range(15, 300)]
+        [MultipleOf(30, ErrorMessage = "Suggested duration must be a multiple of 30 minutes.")]
         public int SuggestedDurationMinutes { get; set; }
 
         // Store the evaluation structure as a JSON string in the database, EF purpose

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
@@ -883,7 +883,12 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
 
             modelBuilder.Entity<InterviewType>(entity =>
             {
-                entity.ToTable("InterviewTypes");
+                entity.ToTable("InterviewTypes", tableBuilder =>
+                {
+                    tableBuilder.HasCheckConstraint(
+                        "CK_InterviewTypes_SuggestedDurationMinutes_MultipleOf30",
+                        "\"SuggestedDurationMinutes\" >= 15 AND \"SuggestedDurationMinutes\" <= 300 AND \"SuggestedDurationMinutes\" % 30 = 0");
+                });
 
                 entity.HasKey(e => e.Id);
 
@@ -913,7 +918,12 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
             // CoachInterviewService (many-to-many with payload: Coach × InterviewType)
             modelBuilder.Entity<CoachInterviewService>(b =>
             {
-                b.ToTable("CoachInterviewServices");
+                b.ToTable("CoachInterviewServices", tableBuilder =>
+                {
+                    tableBuilder.HasCheckConstraint(
+                        "CK_CoachInterviewServices_DurationMinutes_MultipleOf30",
+                        "\"DurationMinutes\" >= 15 AND \"DurationMinutes\" <= 300 AND \"DurationMinutes\" % 30 = 0");
+                });
                 b.HasKey(x => x.Id);
 
                 b.Property(x => x.Price).IsRequired();
@@ -2003,7 +2013,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
                 Name = "Soft Skills Interview",
                 Description = "Behavioral interview focused on communication and interpersonal skills.",
                 IsCoding = false,
-                SuggestedDurationMinutes = 45,
+                SuggestedDurationMinutes = 60,
                 MinPrice = 1000,
                 MaxPrice = 2000,
                 Status = InterviewTypeStatus.Active,
@@ -2022,7 +2032,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
                 Name = "Mock Interview",
                 Description = "Full mock interview simulating a real job interview experience.",
                 IsCoding = true,
-                SuggestedDurationMinutes = 75,
+                SuggestedDurationMinutes = 90,
                 MinPrice = 1000,
                 MaxPrice = 2000,
                 Status = InterviewTypeStatus.Active,
@@ -2060,7 +2070,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
                     CoachId = user2Id,
                     InterviewTypeId = Guid.Parse("5c9e2a14-73bb-4b61-b7e2-91a8f42d3c6e"),
                     Price = 2000,
-                    DurationMinutes = 45,
+                    DurationMinutes = 60,
                 },
                 new CoachInterviewService
                 {
@@ -2068,7 +2078,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
                     CoachId = user2Id,
                     InterviewTypeId = Guid.Parse("f14a7c6d-88b2-4d55-a9fd-2b4e73c91a08"),
                     Price = 2000,
-                    DurationMinutes = 75,
+                    DurationMinutes = 90,
                 }
             );
         }

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260409170722_EnforceDurationMultiplesBy30.Designer.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260409170722_EnforceDurationMultiplesBy30.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intervu.Infrastructure.Persistence.PostgreSQL.DataContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Intervu.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(IntervuPostgreDbContext))]
-    partial class IntervuPostgreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409170722_EnforceDurationMultiplesBy30")]
+    partial class EnforceDurationMultiplesBy30
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260409170722_EnforceDurationMultiplesBy30.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260409170722_EnforceDurationMultiplesBy30.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intervu.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class EnforceDurationMultiplesBy30 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                     UPDATE "InterviewTypes"
+                     SET "SuggestedDurationMinutes" = LEAST(300, GREATEST(30, (("SuggestedDurationMinutes" + 29) / 30) * 30))
+                     WHERE "SuggestedDurationMinutes" % 30 <> 0
+                         OR "SuggestedDurationMinutes" < 15
+                         OR "SuggestedDurationMinutes" > 300;
+                """);
+
+            migrationBuilder.Sql(
+                """
+                     UPDATE "CoachInterviewServices"
+                     SET "DurationMinutes" = LEAST(300, GREATEST(30, (("DurationMinutes" + 29) / 30) * 30))
+                     WHERE "DurationMinutes" % 30 <> 0
+                         OR "DurationMinutes" < 15
+                         OR "DurationMinutes" > 300;
+                """);
+
+            migrationBuilder.UpdateData(
+                table: "CoachInterviewServices",
+                keyColumn: "Id",
+                keyValue: new Guid("019d1467-d415-79f8-9bdc-5bb25a0b25cd"),
+                column: "DurationMinutes",
+                value: 90);
+
+            migrationBuilder.UpdateData(
+                table: "CoachInterviewServices",
+                keyColumn: "Id",
+                keyValue: new Guid("019d1467-d415-79f8-9bdc-5bb25a0b25cf"),
+                column: "DurationMinutes",
+                value: 60);
+
+            migrationBuilder.UpdateData(
+                table: "InterviewTypes",
+                keyColumn: "Id",
+                keyValue: new Guid("5c9e2a14-73bb-4b61-b7e2-91a8f42d3c6e"),
+                column: "SuggestedDurationMinutes",
+                value: 60);
+
+            migrationBuilder.UpdateData(
+                table: "InterviewTypes",
+                keyColumn: "Id",
+                keyValue: new Guid("f14a7c6d-88b2-4d55-a9fd-2b4e73c91a08"),
+                column: "SuggestedDurationMinutes",
+                value: 90);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_InterviewTypes_SuggestedDurationMinutes_MultipleOf30",
+                table: "InterviewTypes",
+                sql: "\"SuggestedDurationMinutes\" >= 15 AND \"SuggestedDurationMinutes\" <= 300 AND \"SuggestedDurationMinutes\" % 30 = 0");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_CoachInterviewServices_DurationMinutes_MultipleOf30",
+                table: "CoachInterviewServices",
+                sql: "\"DurationMinutes\" >= 15 AND \"DurationMinutes\" <= 300 AND \"DurationMinutes\" % 30 = 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_InterviewTypes_SuggestedDurationMinutes_MultipleOf30",
+                table: "InterviewTypes");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_CoachInterviewServices_DurationMinutes_MultipleOf30",
+                table: "CoachInterviewServices");
+
+            migrationBuilder.UpdateData(
+                table: "CoachInterviewServices",
+                keyColumn: "Id",
+                keyValue: new Guid("019d1467-d415-79f8-9bdc-5bb25a0b25cd"),
+                column: "DurationMinutes",
+                value: 75);
+
+            migrationBuilder.UpdateData(
+                table: "CoachInterviewServices",
+                keyColumn: "Id",
+                keyValue: new Guid("019d1467-d415-79f8-9bdc-5bb25a0b25cf"),
+                column: "DurationMinutes",
+                value: 45);
+
+            migrationBuilder.UpdateData(
+                table: "InterviewTypes",
+                keyColumn: "Id",
+                keyValue: new Guid("5c9e2a14-73bb-4b61-b7e2-91a8f42d3c6e"),
+                column: "SuggestedDurationMinutes",
+                value: 45);
+
+            migrationBuilder.UpdateData(
+                table: "InterviewTypes",
+                keyColumn: "Id",
+                keyValue: new Guid("f14a7c6d-88b2-4d55-a9fd-2b4e73c91a08"),
+                column: "SuggestedDurationMinutes",
+                value: 75);
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Duration values for interview types and coach interview services must now be multiples of 30 minutes (between 15 and 300 minutes).

* **Tests**
  * Added validation tests to verify the system rejects durations that don't meet the 30-minute interval requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->