### PR TITLE
feat: Add AI CV evaluation feature and tests

### DIFF
--- a/Intervu.API.Test/ApiTests/InterviewBookingController/ViewRevenueStatistics.cs
+++ b/Intervu.API.Test/ApiTests/InterviewBookingController/ViewRevenueStatistics.cs
@@ -1,4 +1,8 @@
 using Intervu.API.Test.Base;
+using Intervu.API.Test.Utils;
+using Intervu.Application.DTOs.User;
+using System.Net;
+using System.Text.Json;
 using Xunit.Abstractions;
 
 namespace Intervu.API.Test.ApiTests.InterviewBookingController
@@ -6,13 +10,87 @@ namespace Intervu.API.Test.ApiTests.InterviewBookingController
     public class ViewRevenueStatisticsTests : BaseTest, IClassFixture<BaseApiTest<Program>>
     {
         // IC-56
+        private readonly ApiHelper _api;
+
         public ViewRevenueStatisticsTests(BaseApiTest<Program> factory, ITestOutputHelper output) : base(output)
         {
+            _api = new ApiHelper(factory.CreateClient());
         }
 
-        [Fact(Skip = "Revenue statistics endpoint is not explicitly covered in current tests.")]
+        private async Task<string> LoginAdminAsync()
+        {
+            var response = await _api.PostAsync("/api/v1/account/login", new LoginRequest { Email = ADMIN_EMAIL, Password = DEFAULT_PASSWORD });
+            var loginData = await _api.LogDeserializeJson<LoginResponse>(response);
+            return loginData.Data!.Token;
+        }
+
+        private async Task<string> LoginUserAsync(string email)
+        {
+            var response = await _api.PostAsync("/api/v1/account/login", new LoginRequest { Email = email, Password = DEFAULT_PASSWORD });
+            var loginData = await _api.LogDeserializeJson<LoginResponse>(response);
+            return loginData.Data!.Token;
+        }
+
+        [Fact]
         [Trait("Category", "API")]
         [Trait("Category", "InterviewBooking")]
-        public Task ViewRevenueStatistics_Placeholder() => Task.CompletedTask;
+        public async Task GetRevenueStatistics_Success_ReturnsOk()
+        {
+            var token = await LoginAdminAsync();
+
+            var response = await _api.GetAsync("/api/v1/admin/revenue-statistics?startDate=2023-01-01&endDate=2023-12-31", jwtToken: token, logBody: true);
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Status code is 200 OK");
+            await AssertHelper.AssertTrue(payload.Success, "Request successful");
+            await AssertHelper.AssertNotNull(payload.Data, "Revenue data is returned");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewBooking")]
+        public async Task GetRevenueStatistics_Unauthorized_ReturnsUnauthorized()
+        {
+            var response = await _api.GetAsync("/api/v1/admin/revenue-statistics?startDate=2023-01-01&endDate=2023-12-31", logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Unauthenticated user should get 401 Unauthorized");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewBooking")]
+        public async Task GetRevenueStatistics_Forbidden_ReturnsForbidden()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+
+            var response = await _api.GetAsync("/api/v1/admin/revenue-statistics?startDate=2023-01-01&endDate=2023-12-31", jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Forbidden, response.StatusCode, "Non-admin user should get 403 Forbidden");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewBooking")]
+        public async Task GetRevenueStatistics_InvalidDates_ReturnsBadRequest()
+        {
+            var token = await LoginAdminAsync();
+
+            // End date before start date
+            var response = await _api.GetAsync("/api/v1/admin/revenue-statistics?startDate=2023-12-31&endDate=2023-01-01", jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Invalid date range should return 400 Bad Request");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewBooking")]
+        public async Task GetRevenueStatistics_MissingDates_ReturnsBadRequest()
+        {
+            var token = await LoginAdminAsync();
+
+            var response = await _api.GetAsync("/api/v1/admin/revenue-statistics", jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Missing start/end dates should return 400 Bad Request");
+        }
     }
 }

--- a/Intervu.API.Test/ApiTests/InterviewBookingController/ViewUpcomingInterviewSession.cs
+++ b/Intervu.API.Test/ApiTests/InterviewBookingController/ViewUpcomingInterviewSession.cs
@@ -1,4 +1,8 @@
 using Intervu.API.Test.Base;
+using Intervu.API.Test.Utils;
+using Intervu.Application.DTOs.User;
+using System.Net;
+using System.Text.Json;
 using Xunit.Abstractions;
 
 namespace Intervu.API.Test.ApiTests.InterviewBookingController
@@ -6,13 +10,85 @@ namespace Intervu.API.Test.ApiTests.InterviewBookingController
     // IC-40
     public class ViewUpcomingInterviewSessionTests : BaseTest, IClassFixture<BaseApiTest<Program>>
     {
+        private readonly ApiHelper _api;
+
         public ViewUpcomingInterviewSessionTests(BaseApiTest<Program> factory, ITestOutputHelper output) : base(output)
         {
+            _api = new ApiHelper(factory.CreateClient());
         }
 
-        [Fact(Skip = "No dedicated upcoming-session API test exists yet; add when endpoint contract is finalized.")]
+        private async Task<string> LoginUserAsync(string email)
+        {
+            var response = await _api.PostAsync("/api/v1/account/login", new LoginRequest { Email = email, Password = DEFAULT_PASSWORD });
+            var loginData = await _api.LogDeserializeJson<LoginResponse>(response);
+            return loginData.Data!.Token;
+        }
+
+        [Fact]
         [Trait("Category", "API")]
-        [Trait("Category", "InterviewBooking")]
-        public Task ViewUpcomingInterviewSession_Placeholder() => Task.CompletedTask;
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetUpcomingSessions_Success_ReturnsOk()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+
+            var response = await _api.GetAsync("/api/v1/interview-room/upcoming-sessions", jwtToken: token, logBody: true);
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Status code is 200 OK");
+            await AssertHelper.AssertTrue(payload.Success, "Request successful");
+            await AssertHelper.AssertNotNull(payload.Data, "Upcoming sessions data is returned");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetUpcomingSessions_Unauthorized_ReturnsUnauthorized()
+        {
+            var response = await _api.GetAsync("/api/v1/interview-room/upcoming-sessions", logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Unauthenticated user should get 401 Unauthorized");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetUpcomingSessions_EmptyResults_ReturnsOk()
+        {
+            // Assuming Bob has no upcoming sessions
+            var token = await LoginUserAsync("bob@example.com");
+
+            var response = await _api.GetAsync("/api/v1/interview-room/upcoming-sessions", jwtToken: token, logBody: true);
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Status code is 200 OK for no upcoming sessions");
+            await AssertHelper.AssertTrue(payload.Success, "Request successful");
+            await AssertHelper.AssertEqual(0, payload.Data.GetArrayLength(), "Data should be an empty list");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetUpcomingSessions_Pagination_ReturnsCorrectData()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+
+            var response = await _api.GetAsync("/api/v1/interview-room/upcoming-sessions?page=1&pageSize=5", jwtToken: token, logBody: true);
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Status code is 200 OK for paginated request");
+            await AssertHelper.AssertTrue(payload.Success, "Paginated request successful");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetUpcomingSessions_InvalidPage_ReturnsBadRequest()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+
+            var response = await _api.GetAsync("/api/v1/interview-room/upcoming-sessions?page=0", jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Invalid page 0 should return 400 Bad Request");
+        }
     }
 }

--- a/Intervu.API.Test/ApiTests/InterviewRoomController/ReportInterviewProblem.cs
+++ b/Intervu.API.Test/ApiTests/InterviewRoomController/ReportInterviewProblem.cs
@@ -1,7 +1,9 @@
 using Intervu.API.Test.Base;
 using Intervu.API.Test.Utils;
 using Intervu.Application.DTOs.InterviewRoom;
+using Intervu.Application.DTOs.User;
 using System.Net;
+using System.Text.Json;
 using Xunit.Abstractions;
 
 namespace Intervu.API.Test.ApiTests.InterviewRoomController
@@ -10,24 +12,100 @@ namespace Intervu.API.Test.ApiTests.InterviewRoomController
     public class ReportInterviewProblemTests : BaseTest, IClassFixture<BaseApiTest<Program>>
     {
         private readonly ApiHelper _api;
+        private readonly Guid _existingRoomId = Guid.Parse("5c5d6e7f-9a8b-4d3c-8e9b-7c6d5e4f3a66"); // Assuming this is a valid room ID for testing
 
         public ReportInterviewProblemTests(BaseApiTest<Program> factory, ITestOutputHelper output) : base(output)
         {
             _api = new ApiHelper(factory.CreateClient());
         }
 
+        private async Task<string> LoginUserAsync(string email)
+        {
+            var response = await _api.PostAsync("/api/v1/account/login", new LoginRequest { Email = email, Password = DEFAULT_PASSWORD });
+            var loginData = await _api.LogDeserializeJson<LoginResponse>(response);
+            return loginData.Data!.Token;
+        }
+
         [Fact]
         [Trait("Category", "API")]
         [Trait("Category", "InterviewRoom")]
-        public async Task ReportInterviewProblem_ReturnsUnauthorized_WhenNoToken()
+        public async Task ReportInterviewProblem_Success_ReturnsOk()
         {
-            var response = await _api.PostAsync($"/api/v1/interviewroom/{Guid.NewGuid()}/report", new CreateRoomReportRequest
+            var token = await LoginUserAsync("alice@example.com"); // Assuming Alice is in the room
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/report", new CreateRoomReportRequest
             {
                 Reason = "Audio issue",
                 Details = "Mic was disconnected during interview"
+            }, jwtToken: token, logBody: true);
+
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
+            await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Report problem status is 200 OK");
+            await AssertHelper.AssertTrue(payload.Success, "Report problem successful");
+            await AssertHelper.AssertEqual("Problem reported successfully", payload.Message, "Success message matches");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task ReportInterviewProblem_Unauthorized_ReturnsUnauthorized()
+        {
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/report", new CreateRoomReportRequest
+            {
+                Reason = "Video issue",
+                Details = "Camera not working"
             }, logBody: true);
 
-            await AssertHelper.AssertEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Status code is 401 Unauthorized");
+            await AssertHelper.AssertEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Unauthenticated user should get 401 Unauthorized");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task ReportInterviewProblem_NonExistentRoom_ReturnsNotFound()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+            var nonExistentRoomId = Guid.NewGuid();
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{nonExistentRoomId}/report", new CreateRoomReportRequest
+            {
+                Reason = "Room not found",
+                Details = "Attempted to report problem for a room that does not exist."
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.NotFound, response.StatusCode, "Non-existent room ID should return 404 Not Found");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task ReportInterviewProblem_MissingReason_ReturnsBadRequest()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/report", new CreateRoomReportRequest
+            {
+                Reason = "", // Missing reason
+                Details = "Details provided but reason is empty."
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Missing reason should return 400 Bad Request");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task ReportInterviewProblem_UserNotInRoom_ReturnsForbidden()
+        {
+            var token = await LoginUserAsync("bob@example.com"); // Assuming Bob is NOT in _existingRoomId
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/report", new CreateRoomReportRequest
+            {
+                Reason = "Unauthorized report",
+                Details = "User not part of this room."
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Forbidden, response.StatusCode, "User not in room should get 403 Forbidden");
         }
     }
 }

--- a/Intervu.API.Test/ApiTests/InterviewRoomController/UseLiveCodingEditor.cs
+++ b/Intervu.API.Test/ApiTests/InterviewRoomController/UseLiveCodingEditor.cs
@@ -1,4 +1,8 @@
 using Intervu.API.Test.Base;
+using Intervu.API.Test.Utils;
+using Intervu.Application.DTOs.User;
+using System.Net;
+using System.Text.Json;
 using Xunit.Abstractions;
 
 namespace Intervu.API.Test.ApiTests.InterviewRoomController
@@ -6,13 +10,108 @@ namespace Intervu.API.Test.ApiTests.InterviewRoomController
     // IC-43: realtime function, can not test via unit test
     public class UseLiveCodingEditorTests : BaseTest, IClassFixture<BaseApiTest<Program>>
     {
+        private readonly ApiHelper _api;
+        private readonly Guid _existingRoomId = Guid.Parse("5c5d6e7f-9a8b-4d3c-8e9b-7c6d5e4f3a66"); // Assuming this is a valid room ID for testing
+
         public UseLiveCodingEditorTests(BaseApiTest<Program> factory, ITestOutputHelper output) : base(output)
         {
+            _api = new ApiHelper(factory.CreateClient());
         }
 
-        [Fact(Skip = "Live coding editor API flows are not currently covered in backend API tests.")]
+        private async Task<string> LoginUserAsync(string email)
+        {
+            var response = await _api.PostAsync("/api/v1/account/login", new LoginRequest { Email = email, Password = DEFAULT_PASSWORD });
+            var loginData = await _api.LogDeserializeJson<LoginResponse>(response);
+            return loginData.Data!.Token;
+        }
+
+        [Fact]
         [Trait("Category", "API")]
         [Trait("Category", "InterviewRoom")]
-        public Task UseLiveCodingEditor_Placeholder() => Task.CompletedTask;
+        public async Task UpdateEditorContent_Success_ReturnsOk()
+        {
+            var token = await LoginUserAsync("bob@example.com"); // Assuming Bob is in the room
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/editor-content", new
+            {
+                Content = "console.log('Hello World');",
+                Language = "javascript"
+            }, jwtToken: token, logBody: true);
+
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
+            await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Update editor content status is 200 OK");
+            await AssertHelper.AssertTrue(payload.Success, "Update editor content successful");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task UpdateEditorContent_Unauthorized_ReturnsUnauthorized()
+        {
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/editor-content", new
+            {
+                Content = "console.log('Unauthorized');",
+                Language = "javascript"
+            }, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Unauthenticated user should get 401 Unauthorized");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task UpdateEditorContent_NonExistentRoom_ReturnsNotFound()
+        {
+            var token = await LoginUserAsync("bob@example.com");
+            var nonExistentRoomId = Guid.NewGuid();
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{nonExistentRoomId}/editor-content", new
+            {
+                Content = "console.log('Non-existent room');",
+                Language = "javascript"
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.NotFound, response.StatusCode, "Non-existent room ID should return 404 Not Found");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task UpdateEditorContent_MissingContentOrLanguage_ReturnsBadRequest()
+        {
+            var token = await LoginUserAsync("bob@example.com");
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/editor-content", new
+            {
+                Content = "", // Missing content
+                Language = "python"
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Missing content should return 400 Bad Request");
+
+            response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/editor-content", new
+            {
+                Content = "print('Hello');",
+                Language = "" // Missing language
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Missing language should return 400 Bad Request");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task UpdateEditorContent_UserNotInRoom_ReturnsForbidden()
+        {
+            var token = await LoginUserAsync("alice@example.com"); // Assuming Alice is NOT in the room
+
+            var response = await _api.PostAsync($"/api/v1/interview-room/{_existingRoomId}/editor-content", new
+            {
+                Content = "console.log('Forbidden');",
+                Language = "javascript"
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Forbidden, response.StatusCode, "User not in room should get 403 Forbidden");
+        }
     }
 }

--- a/Intervu.API.Test/ApiTests/InterviewRoomController/ViewFinishedInterviewSessionDetail.cs
+++ b/Intervu.API.Test/ApiTests/InterviewRoomController/ViewFinishedInterviewSessionDetail.cs
@@ -1,4 +1,8 @@
 using Intervu.API.Test.Base;
+using Intervu.API.Test.Utils;
+using Intervu.Application.DTOs.User;
+using System.Net;
+using System.Text.Json;
 using Xunit.Abstractions;
 
 namespace Intervu.API.Test.ApiTests.InterviewRoomController
@@ -6,13 +10,82 @@ namespace Intervu.API.Test.ApiTests.InterviewRoomController
     // IC-48
     public class ViewFinishedInterviewSessionDetailTests : BaseTest, IClassFixture<BaseApiTest<Program>>
     {
+        private readonly ApiHelper _api;
+        private readonly Guid _existingSessionId = Guid.Parse("a1b2c3d4-e5f6-7890-1234-567890abcdef"); // Assuming this is a valid finished session ID for testing
+
         public ViewFinishedInterviewSessionDetailTests(BaseApiTest<Program> factory, ITestOutputHelper output) : base(output)
         {
+            _api = new ApiHelper(factory.CreateClient());
         }
 
-        [Fact(Skip = "Finished-session detail endpoint coverage is not explicitly present in current tests.")]
+        private async Task<string> LoginUserAsync(string email)
+        {
+            var response = await _api.PostAsync("/api/v1/account/login", new LoginRequest { Email = email, Password = DEFAULT_PASSWORD });
+            var loginData = await _api.LogDeserializeJson<LoginResponse>(response);
+            return loginData.Data!.Token;
+        }
+
+        [Fact]
         [Trait("Category", "API")]
         [Trait("Category", "InterviewRoom")]
-        public Task ViewFinishedInterviewSessionDetail_Placeholder() => Task.CompletedTask;
+        public async Task GetFinishedSessionDetail_Success_ReturnsOk()
+        {
+            var token = await LoginUserAsync("alice@example.com"); // Assuming Alice participated in _existingSessionId
+
+            var response = await _api.GetAsync($"/api/v1/interview-room/finished-sessions/{_existingSessionId}", jwtToken: token, logBody: true);
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Status code is 200 OK");
+            await AssertHelper.AssertTrue(payload.Success, "Request successful");
+            await AssertHelper.AssertNotNull(payload.Data, "Finished session detail data is returned");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetFinishedSessionDetail_Unauthorized_ReturnsUnauthorized()
+        {
+            var response = await _api.GetAsync($"/api/v1/interview-room/finished-sessions/{_existingSessionId}", logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Unauthenticated user should get 401 Unauthorized");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetFinishedSessionDetail_NonExistentSession_ReturnsNotFound()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+            var nonExistentSessionId = Guid.NewGuid();
+
+            var response = await _api.GetAsync($"/api/v1/interview-room/finished-sessions/{nonExistentSessionId}", jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.NotFound, response.StatusCode, "Non-existent session ID should return 404 Not Found");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetFinishedSessionDetail_UserNotInSession_ReturnsForbidden()
+        {
+            var token = await LoginUserAsync("bob@example.com"); // Assuming Bob did NOT participate in _existingSessionId
+
+            var response = await _api.GetAsync($"/api/v1/interview-room/finished-sessions/{_existingSessionId}", jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Forbidden, response.StatusCode, "User not in session should get 403 Forbidden");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "InterviewRoom")]
+        public async Task GetFinishedSessionDetail_InvalidSessionIdFormat_ReturnsBadRequest()
+        {
+            var token = await LoginUserAsync("alice@example.com");
+            var invalidSessionId = "not-a-valid-guid";
+
+            var response = await _api.GetAsync($"/api/v1/interview-room/finished-sessions/{invalidSessionId}", jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Invalid session ID format should return 400 Bad Request");
+        }
     }
 }

--- a/Intervu.API.Test/ApiTests/RescheduleRequestController/RescheduleInterviewSession.cs
+++ b/Intervu.API.Test/ApiTests/RescheduleRequestController/RescheduleInterviewSession.cs
@@ -3,6 +3,7 @@ using Intervu.API.Test.Utils;
 using Intervu.Application.DTOs.RescheduleRequest;
 using Intervu.Application.DTOs.User;
 using System.Net;
+using System.Text.Json;
 using Xunit.Abstractions;
 
 namespace Intervu.API.Test.ApiTests.RescheduleRequestController
@@ -11,7 +12,8 @@ namespace Intervu.API.Test.ApiTests.RescheduleRequestController
     public class RescheduleInterviewSessionTests : BaseTest, IClassFixture<BaseApiTest<Program>>
     {
         private readonly ApiHelper _api;
-        private readonly Guid _roomRescheduleCreateId = Guid.Parse("b1b1b1b1-2222-4a1a-8a1a-222222222222");
+        private readonly Guid _roomRescheduleCreateId = Guid.Parse("b1b1b1b1-2222-4a1a-8a1a-222222222222"); // Assuming this is a valid, upcoming room ID
+        private readonly Guid _nonExistentRoomId = Guid.NewGuid();
 
         public RescheduleInterviewSessionTests(BaseApiTest<Program> factory, ITestOutputHelper output) : base(output)
         {
@@ -25,36 +27,110 @@ namespace Intervu.API.Test.ApiTests.RescheduleRequestController
             return loginData.Data!.Token;
         }
 
+        private async Task<string> LoginAsBobAsync()
+        {
+            var loginResponse = await _api.PostAsync("/api/v1/account/login", new LoginRequest { Email = "bob@example.com", Password = DEFAULT_PASSWORD });
+            var loginData = await _api.LogDeserializeJson<LoginResponse>(loginResponse);
+            return loginData.Data!.Token;
+        }
+
         [Fact]
         [Trait("Category", "API")]
         [Trait("Category", "RescheduleRequest")]
         public async Task CreateRescheduleRequest_WithValidData_ReturnsSuccess()
         {
             var token = await LoginAsAliceAsync();
+            var newStartTime = DateTime.UtcNow.AddDays(2).AddHours(1).AddMinutes(30); // Ensure it's in the future and aligned
             var response = await _api.PostAsync("/api/v1/reschedule-requests", new CreateRescheduleRequestDto
             {
                 RoomId = _roomRescheduleCreateId,
-                NewStartTime = DateTime.UtcNow.AddDays(2),
-                Reason = "Need to reschedule due to personal emergency that requires my immediate attention"
+                NewStartTime = newStartTime,
+                Reason = "Need to reschedule due to personal emergency that requires my immediate attention."
             }, jwtToken: token, logBody: true);
 
+            var payload = await _api.LogDeserializeJson<JsonElement>(response, true);
             await AssertHelper.AssertEqual(HttpStatusCode.OK, response.StatusCode, "Status code is 200 OK");
+            await AssertHelper.AssertTrue(payload.Success, "Reschedule request successful");
+            await AssertHelper.AssertEqual("Reschedule request created successfully", payload.Message, "Success message matches");
         }
 
         [Fact]
         [Trait("Category", "API")]
         [Trait("Category", "RescheduleRequest")]
-        public async Task CreateRescheduleRequest_WithShortReason_ReturnsBadRequest()
+        public async Task CreateRescheduleRequest_Unauthorized_ReturnsUnauthorized()
+        {
+            var response = await _api.PostAsync("/api/v1/reschedule-requests", new CreateRescheduleRequestDto
+            {
+                RoomId = _roomRescheduleCreateId,
+                NewStartTime = DateTime.UtcNow.AddDays(2),
+                Reason = "Unauthorized attempt."
+            }, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Unauthenticated user should get 401 Unauthorized");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "RescheduleRequest")]
+        public async Task CreateRescheduleRequest_NonExistentRoom_ReturnsNotFound()
+        {
+            var token = await LoginAsAliceAsync();
+            var response = await _api.PostAsync("/api/v1/reschedule-requests", new CreateRescheduleRequestDto
+            {
+                RoomId = _nonExistentRoomId,
+                NewStartTime = DateTime.UtcNow.AddDays(2),
+                Reason = "Room does not exist."
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.NotFound, response.StatusCode, "Non-existent room ID should return 404 Not Found");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "RescheduleRequest")]
+        public async Task CreateRescheduleRequest_NewStartTimeInPast_ReturnsBadRequest()
         {
             var token = await LoginAsAliceAsync();
             var response = await _api.PostAsync("/api/v1/reschedule-requests", new CreateRescheduleRequestDto
             {
                 RoomId = _roomRescheduleCreateId,
-                NewStartTime = DateTime.UtcNow.AddDays(2),
-                Reason = "Short"
+                NewStartTime = DateTime.UtcNow.AddDays(-1), // Past date
+                Reason = "Cannot reschedule to a past time."
             }, jwtToken: token, logBody: true);
 
-            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Status code is 400 Bad Request");
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Past NewStartTime should return 400 Bad Request");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "RescheduleRequest")]
+        public async Task CreateRescheduleRequest_MissingReason_ReturnsBadRequest()
+        {
+            var token = await LoginAsAliceAsync();
+            var response = await _api.PostAsync("/api/v1/reschedule-requests", new CreateRescheduleRequestDto
+            {
+                RoomId = _roomRescheduleCreateId,
+                NewStartTime = DateTime.UtcNow.AddDays(3),
+                Reason = "" // Empty reason
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.BadRequest, response.StatusCode, "Missing reason should return 400 Bad Request");
+        }
+
+        [Fact]
+        [Trait("Category", "API")]
+        [Trait("Category", "RescheduleRequest")]
+        public async Task CreateRescheduleRequest_UserNotInRoom_ReturnsForbidden()
+        {
+            var token = await LoginAsBobAsync(); // Assuming Bob is not in _roomRescheduleCreateId
+            var response = await _api.PostAsync("/api/v1/reschedule-requests", new CreateRescheduleRequestDto
+            {
+                RoomId = _roomRescheduleCreateId,
+                NewStartTime = DateTime.UtcNow.AddDays(4),
+                Reason = "User not part of this interview session."
+            }, jwtToken: token, logBody: true);
+
+            await AssertHelper.AssertEqual(HttpStatusCode.Forbidden, response.StatusCode, "User not in room should get 403 Forbidden");
         }
     }
 }

--- a/Intervu.API/Controllers/v1/Candidate/CandidateProfileController.cs
+++ b/Intervu.API/Controllers/v1/Candidate/CandidateProfileController.cs
@@ -1,4 +1,4 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using AutoMapper;
 using Intervu.API.Utils.Constant;
 using Intervu.Application.DTOs.Candidate;
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Security.Claims;
 
 namespace Intervu.API.Controllers.v1.Candidate
 {
@@ -24,6 +25,7 @@ namespace Intervu.API.Controllers.v1.Candidate
         private readonly IViewCandidateProfile _getCandidateProfile;
         private readonly IDeleteCandidateProfile _deleteCandidateProfile;
         private readonly IGetCandidateRating _getCandidateRating;
+        private readonly IEvaluateCandidateCv _evaluateCandidateCv;
         private readonly ICandidateProfileRepository _repo;
 
         public CandidateProfileController(
@@ -32,6 +34,7 @@ namespace Intervu.API.Controllers.v1.Candidate
             IViewCandidateProfile getCandidateProfile,
             IDeleteCandidateProfile deleteCandidateProfile,
             IGetCandidateRating getCandidateRating,
+            IEvaluateCandidateCv evaluateCandidateCv,
             ICandidateProfileRepository repo)
         {
             _createCandidateProfile = createCandidateProfile;
@@ -39,6 +42,7 @@ namespace Intervu.API.Controllers.v1.Candidate
             _getCandidateProfile = getCandidateProfile;
             _deleteCandidateProfile = deleteCandidateProfile;
             _getCandidateRating = getCandidateRating;
+            _evaluateCandidateCv = evaluateCandidateCv;
             _repo = repo;
         }
 
@@ -369,5 +373,38 @@ namespace Intervu.API.Controllers.v1.Candidate
             return Ok(new { success = true });
         }
 
+        // [POST] api/candidate-profile/evaluate-cv
+        [Authorize(Policy = AuthorizationPolicies.Candidate)]
+        [HttpPost("evaluate-cv")]
+        public async Task<IActionResult> EvaluateCv([FromForm] IFormFile? file = null)
+        {
+            try
+            {
+                var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (string.IsNullOrEmpty(userIdString))
+                {
+                    return Unauthorized(new { success = false, message = "User not identified" });
+                }
+
+                var userId = Guid.Parse(userIdString);
+
+                var result = await _evaluateCandidateCv.ExecuteAsync(userId, file);
+                if (result == null)
+                {
+                    return BadRequest(new { success = false, message = "Failed to evaluate CV" });
+                }
+
+                if (!string.IsNullOrEmpty(result.Error))
+                {
+                    return BadRequest(new { success = false, message = result.Error });
+                }
+
+                return Ok(new { success = true, data = result });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { success = false, message = ex.Message });
+            }
+        }
     }
 }

--- a/Intervu.Application/DTOs/Ai/AiCvEvaluationResponseDto.cs
+++ b/Intervu.Application/DTOs/Ai/AiCvEvaluationResponseDto.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Intervu.Application.DTOs.Ai
+{
+    public class AiCvEvaluationResponseDto
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("summary")]
+        public string Summary { get; set; } = string.Empty;
+
+        [JsonPropertyName("strengths")]
+        public List<string> Strengths { get; set; } = new();
+
+        [JsonPropertyName("gaps")]
+        public List<string> Gaps { get; set; } = new();
+
+        [JsonPropertyName("reasoning")]
+        public string Reasoning { get; set; } = string.Empty;
+
+        [JsonPropertyName("final_verdict")]
+        public string FinalVerdict { get; set; } = string.Empty;
+
+        [JsonIgnore]
+        public string? Error { get; set; }
+    }
+}

--- a/Intervu.Application/DTOs/Candidate/CandidateProfileDto.cs
+++ b/Intervu.Application/DTOs/Candidate/CandidateProfileDto.cs
@@ -16,5 +16,7 @@ namespace Intervu.Application.DTOs.Candidate
         public ICollection<CandidateWorkExperienceDto> WorkExperiences { get; set; } = new List<CandidateWorkExperienceDto>();
         public string? Bio { get; set; }
         public int CurrentAmount { get; set; }
+
+        public string? AIEvaluation { get; set; }
     }
 }

--- a/Intervu.Application/DTOs/Candidate/CandidateViewDto.cs
+++ b/Intervu.Application/DTOs/Candidate/CandidateViewDto.cs
@@ -15,5 +15,6 @@ namespace Intervu.Application.DTOs.Candidate
         public ICollection<CandidateCertificateDto>? CertificationLinks { get; set; }
         public ICollection<CandidateWorkExperienceDto> WorkExperiences { get; set; } = new List<CandidateWorkExperienceDto>();
         public string? Bio { get; set; }
+        public string? AIEvaluation { get; set; }
     }
 }

--- a/Intervu.Application/DependencyInjection.cs
+++ b/Intervu.Application/DependencyInjection.cs
@@ -185,6 +185,7 @@ namespace Intervu.Application
             services.AddScoped<IUpdateCandidateProfile, UpdateCandidateProfile>();
             services.AddScoped<IViewCandidateProfile, ViewCandidateProfile>();
             services.AddScoped<IDeleteCandidateProfile, DeleteCandidateProfile>();
+            services.AddScoped<IEvaluateCandidateCv, EvaluateCandidateCv>();
 
             // ----- Reschedule Request ----
             services.AddScoped<ICreateRescheduleRequestUseCase, CreateRescheduleRequestUseCase>();

--- a/Intervu.Application/Interfaces/ExternalServices/IAiService.cs
+++ b/Intervu.Application/Interfaces/ExternalServices/IAiService.cs
@@ -15,5 +15,6 @@ namespace Intervu.Application.Interfaces.ExternalServices
         Task<bool> StoreCvUrlAsync(Guid roomId, string cvUrl, IFormFile? file);
         Task<string?> GetLastCvPdfUrlAsync(Guid roomId);
         Task<AiQuestionExtractionResponse> GetNewQuestionsFromTranscriptAsync(byte[] audioData, Guid roomId);
+        Task<AiCvEvaluationResponseDto?> EvaluateCvAsync(System.IO.Stream stream, string fileName, string contentType);
     }
 }

--- a/Intervu.Application/Interfaces/UseCases/CandidateProfile/IEvaluateCandidateCv.cs
+++ b/Intervu.Application/Interfaces/UseCases/CandidateProfile/IEvaluateCandidateCv.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Threading.Tasks;
+using Intervu.Application.DTOs.Ai;
+
+namespace Intervu.Application.Interfaces.UseCases.CandidateProfile
+{
+    public interface IEvaluateCandidateCv
+    {
+        Task<AiCvEvaluationResponseDto?> ExecuteAsync(Guid candidateId, IFormFile? file = null);
+    }
+}

--- a/Intervu.Application/UseCases/BookingRequest/RespondToBookingRequest.cs
+++ b/Intervu.Application/UseCases/BookingRequest/RespondToBookingRequest.cs
@@ -21,12 +21,10 @@ namespace Intervu.Application.UseCases.BookingRequest
         private readonly ICreateEvaluationResultsUseCase _createEvaluationResultsUseCase;
         private readonly IBackgroundService _backgroundService;
         private readonly IMapper _mapper;
-        private readonly IBackgroundService _backgroundService;
         private readonly IUserRepository _userRepository;
 
         public RespondToBookingRequest(
             IBookingRequestRepository bookingRepo,
-            IMapper mapper,
             IUserRepository userRepository,
             ITransactionRepository transactionRepo,
             ICoachAvailabilitiesRepository availabilityRepo,

--- a/Intervu.Application/UseCases/CandidateProfile/EvaluateCandidateCv.cs
+++ b/Intervu.Application/UseCases/CandidateProfile/EvaluateCandidateCv.cs
@@ -1,0 +1,113 @@
+using Intervu.Application.DTOs.Ai;
+using Intervu.Application.Interfaces.ExternalServices;
+using Intervu.Application.Interfaces.UseCases.CandidateProfile;
+using Intervu.Domain.Repositories;
+using Microsoft.AspNetCore.Http;
+using System;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.CandidateProfile
+{
+    public class EvaluateCandidateCv : IEvaluateCandidateCv
+    {
+        private readonly IAiService _aiService;
+        private readonly ICandidateProfileRepository _repository;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<EvaluateCandidateCv> _logger;
+
+        public EvaluateCandidateCv(
+            IAiService aiService, 
+            ICandidateProfileRepository repository,
+            IHttpClientFactory httpClientFactory,
+            ILogger<EvaluateCandidateCv> logger)
+        {
+            _aiService = aiService;
+            _repository = repository;
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        public async Task<AiCvEvaluationResponseDto?> ExecuteAsync(Guid candidateId, IFormFile? file = null)
+        {
+            var profile = await _repository.GetByIdAsync(candidateId);
+            if (profile == null)
+            {
+                _logger.LogWarning("Candidate profile not found for ID: {CandidateId}", candidateId);
+                return null;
+            }
+
+            // 1. One-off Evaluation with Uploaded File (No Save)
+            if (file != null && file.Length > 0)
+            {
+                _logger.LogInformation("Starting one-off CV evaluation for candidate: {CandidateId} with file: {FileName}", candidateId, file.FileName);
+                try
+                {
+                    using var stream = file.OpenReadStream();
+                    var contentType = string.IsNullOrWhiteSpace(file.ContentType) ? "application/pdf" : file.ContentType;
+                    return await _aiService.EvaluateCvAsync(stream, file.FileName, contentType);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error evaluating uploaded file for candidate: {CandidateId}", candidateId);
+                    return new AiCvEvaluationResponseDto { Error = $"Failed to evaluate uploaded file: {ex.Message}" };
+                }
+            }
+
+            // 2. Current CV Evaluation (from DB/URL)
+            // Load from DB Cache if available (unless we want to force re-evaluation, but user requested "it will load from db")
+            if (!string.IsNullOrEmpty(profile.AIEvaluation))
+            {
+                _logger.LogInformation("Found cached AI evaluation for candidate: {CandidateId}. Returning from DB. \n EvaluationResults: {AIEvaluation}", candidateId, profile.AIEvaluation);
+                try
+                {
+                    var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                    return JsonSerializer.Deserialize<AiCvEvaluationResponseDto>(profile.AIEvaluation, options);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to deserialize cached AI evaluation for candidate: {CandidateId}. Re-evaluating.", candidateId);
+                    // If JSON is corrupted, proceed to re-evaluate
+                }
+            }
+
+            if (string.IsNullOrEmpty(profile.CVUrl))
+            {
+                _logger.LogWarning("CV URL is missing for candidate: {CandidateId}. Cannot evaluate.", candidateId);
+                return new AiCvEvaluationResponseDto 
+                { 
+                    Error = "Please upload a cv before using this feature" 
+                };
+            }
+
+            _logger.LogInformation("No cache found. Fetching CV from URL for evaluation. Candidate: {CandidateId}, URL: {CVUrl}", candidateId, profile.CVUrl);
+            try
+            {
+                using var httpClient = _httpClientFactory.CreateClient();
+                using var stream = await httpClient.GetStreamAsync(profile.CVUrl);
+
+                var evaluationResult = await _aiService.EvaluateCvAsync(stream, "cv.pdf", "application/pdf");
+
+                if (evaluationResult == null || !string.IsNullOrEmpty(evaluationResult.Error))
+                {
+                    _logger.LogWarning("AI evaluation returned error or null for candidate: {CandidateId}. Error: {Error}", candidateId, evaluationResult?.Error);
+                    return evaluationResult;
+                }
+
+                _logger.LogInformation("Successfully evaluated CV for candidate: {CandidateId}. Saving to DB cache. \n EvaluationResults: {AIEvaluation}", candidateId, evaluationResult);
+                // Store in Candidate Profile for caching
+                profile.AIEvaluation = JsonSerializer.Serialize(evaluationResult);
+                await _repository.UpdateCandidateProfileAsync(profile);
+
+                return evaluationResult;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Critical failure during CV retrieval or evaluation for candidate: {CandidateId}", candidateId);
+                return new AiCvEvaluationResponseDto { Error = $"Failed to load or evaluate CV: {ex.Message}" };
+            }
+        }
+    }
+}

--- a/Intervu.Application/UseCases/InterviewBooking/CreateBookingCheckoutUrl.cs
+++ b/Intervu.Application/UseCases/InterviewBooking/CreateBookingCheckoutUrl.cs
@@ -38,7 +38,7 @@ namespace Intervu.Application.UseCases.InterviewBooking
             IBackgroundService jobService,
             ICoachInterviewServiceRepository coachInterviewServiceRepository,
             IUserRepository userRepository,
-            IConfiguration configuration)
+            IConfiguration configuration,
             ICreateEvaluationResultsUseCase createEvaluationResults,
             IUnitOfWork unitOfWork)
         {

--- a/Intervu.Domain/Entities/CandidateProfile.cs
+++ b/Intervu.Domain/Entities/CandidateProfile.cs
@@ -32,5 +32,11 @@ namespace Intervu.Domain.Entities
         /// JSON list of saved question snapshots. Nullable.
         /// </summary>
         public List<QuestionSnapshot>? SavedQuestions { get; set; }
+
+        /// <summary>
+        /// AI Evaluation result of the candidate's CV.
+        /// Stored as JSONB in DB.
+        /// </summary>
+        public string? AIEvaluation { get; set; }
     }
 }

--- a/Intervu.Infrastructure/ExternalServices/AiService.cs
+++ b/Intervu.Infrastructure/ExternalServices/AiService.cs
@@ -396,5 +396,47 @@ namespace Intervu.Infrastructure.ExternalServices
                 };
             }
         }
+
+        public async Task<AiCvEvaluationResponseDto?> EvaluateCvAsync(System.IO.Stream stream, string fileName, string contentType)
+        {
+            if (_httpClient.BaseAddress == null || stream == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                var endpoint = "api/evaluate-cv";
+                using var form = new MultipartFormDataContent();
+                
+                // Note: We don't dispose the stream here as it's passed in from outside
+                using var fileContent = new StreamContent(stream);
+                
+                fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                form.Add(fileContent, "file", fileName);
+
+                var response = await _httpClient.PostAsync(endpoint, form);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError("AI service evaluation request failed with status code {StatusCode}", response.StatusCode);
+                    return null;
+                }
+
+                var rawContent = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    ReadCommentHandling = JsonCommentHandling.Skip,
+                    AllowTrailingCommas = true
+                };
+
+                return JsonSerializer.Deserialize<AiCvEvaluationResponseDto>(rawContent, options);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while evaluating CV via AI service.");
+                return null;
+            }
+        }
     }
 }

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
@@ -146,6 +146,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
                 b.Property(x => x.CVUrl).HasMaxLength(1000);
                 b.Property(x => x.PortfolioUrl).HasMaxLength(1000);
                 b.Property(x => x.Bio).HasColumnType("text");
+                b.Property(x => x.AIEvaluation).HasColumnName("AIEvaluation").HasColumnType("jsonb").IsRequired(false);
 
                 var savedQuestionComparer = new Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer<System.Collections.Generic.List<Intervu.Domain.Entities.QuestionSnapshot>>(
                     (c1, c2) => System.Text.Json.JsonSerializer.Serialize(c1, (System.Text.Json.JsonSerializerOptions?)null) == System.Text.Json.JsonSerializer.Serialize(c2, (System.Text.Json.JsonSerializerOptions?)null),

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260410144132_AddAIEvaluation.Designer.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260410144132_AddAIEvaluation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intervu.Infrastructure.Persistence.PostgreSQL.DataContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Intervu.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(IntervuPostgreDbContext))]
-    partial class IntervuPostgreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410144132_AddAIEvaluation")]
+    partial class AddAIEvaluation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260410144132_AddAIEvaluation.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260410144132_AddAIEvaluation.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intervu.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAIEvaluation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AIEvaluation",
+                table: "CandidateProfiles",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "CandidateProfiles",
+                keyColumn: "Id",
+                keyValue: new Guid("0d0b8b1e-2e2c-43e2-9d8e-7d2f7a2a1a11"),
+                column: "AIEvaluation",
+                value: null);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AIEvaluation",
+                table: "CandidateProfiles");
+        }
+    }
+}


### PR DESCRIPTION
Introduce AI-driven CV evaluation and expand API tests.

- Add AiCvEvaluationResponseDto to represent AI evaluation results.
- New IEvaluateCandidateCv use-case and EvaluateCandidateCv implementation: fetches CV (uploaded or from CVUrl), calls IAiService.EvaluateCvAsync, caches JSON result in profile.AIEvaluation and updates repository.
- Extend IAiService with EvaluateCvAsync and implement it in AiService to call external AI endpoint.
- Expose endpoint POST api/v1/candidate-profile/evaluate-cv (authorized candidate) in CandidateProfileController; parse user from claims and return evaluation or errors.
- Add AIEvaluation property to domain entity and DTOs (CandidateProfileDto, CandidateViewDto) and map AIEvaluation as jsonb in EF Core DbContext; register IEvaluateCandidateCv in DI.
- Update CandidateProfileRepository to avoid overwriting AIEvaluation (assignment commented out) while other profile fields continue to be merged.
- Large set of API test updates: introduce ApiHelper usage, login helpers and JSON assertions; add/expand tests for revenue statistics, upcoming sessions, report interview problems, live coding editor, finished session details, and reschedule request scenarios (success, auth, validation, not-found, forbidden cases).

These changes add end-to-end support for evaluating CVs via an AI service and improve test coverage for several controller flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered CV evaluation: upload/evaluate CVs with structured feedback; candidate profiles now include an AIEvaluation field and backend persistence; DB migration added to store evaluations.

* **Tests**
  * Expanded API test coverage across booking, interview room, reschedule, and CV evaluation flows covering success, auth, authorization, validation, pagination, and not-found scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->