### PR TITLE
feat: Add media upload endpoint to UserProfileController

### DIFF
--- a/Intervu.API/Controllers/v1/UserProfileController.cs
+++ b/Intervu.API/Controllers/v1/UserProfileController.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using Intervu.Application.Interfaces.UseCases.CandidateProfile;
 using static Intervu.API.Controllers.v1.InterviewRoomController;
+using Intervu.API.Utils.Constant;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Intervu.API.Controllers.v1
 {
@@ -174,6 +176,32 @@ namespace Intervu.API.Controllers.v1
             {
                 success = true,
                 message = "Success",
+                data = fileUrl
+            });
+        }
+
+        [HttpPost("upload")]
+        [Authorize(Policy = AuthorizationPolicies.AllRoles)]
+        public async Task<IActionResult> UploadMedia([FromForm] IFormFile file, [FromQuery] string? folder = "general")
+        {
+            if (file == null || file.Length == 0)
+            {
+                return BadRequest(new { success = false, message = "File is required" });
+            }
+
+            using var stream = file.OpenReadStream();
+            string fileName = $"{Guid.NewGuid()}{Path.GetExtension(file.FileName)}";
+            
+            // Build object name with folder
+            string cleanFolder = folder?.Trim('/') ?? "general";
+            string objectName = $"{cleanFolder}/{fileName}";
+
+            var fileUrl = await _fileService.UploadFileAsync(stream, objectName, file.ContentType);
+
+            return Ok(new
+            {
+                success = true,
+                message = "File uploaded successfully",
                 data = fileUrl
             });
         }


### PR DESCRIPTION
Introduce a POST /upload action (UploadMedia) in UserProfileController to accept an IFormFile and optional folder query (default "general"). The endpoint validates the file, generates a GUID-based filename, constructs an object path as "folder/filename", uploads the stream via _fileService.UploadFileAsync, and returns the uploaded file URL. Also add authorization (Authorize with AuthorizationPolicies.AllRoles) and required using directives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a file upload endpoint to user profiles with secure authorization controls, input validation, and automatic file processing for media storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->