### PR TITLE
feat: Add SendTranscript hub method

### DIFF
--- a/Intervu.API/Hubs/InterviewRoomHub.cs
+++ b/Intervu.API/Hubs/InterviewRoomHub.cs
@@ -459,6 +459,15 @@ namespace Intervu.API.Hubs
             await Clients.OthersInGroup(roomId).SendAsync("ReceiveMicState", Context.ConnectionId, isOn);
         }
 
+        /// <summary>
+        /// Broadcasts live transcript updates (final or interim) to other participants.
+        /// </summary>
+        public async Task SendTranscript(string roomId, string? final, string? interim, UserRole role)
+        {
+            //if (await isRoomCompleted(roomId)) return;
+            await Clients.OthersInGroup(roomId).SendAsync("ReceiveTranscript", Context.ConnectionId, final, interim, role);
+        }
+
         public async Task<bool> isRoomCompleted(string roomId)
         {
             var room = _cache.Rooms.SingleOrDefault(r => r.Id == Guid.Parse(roomId));


### PR DESCRIPTION
Add SendTranscript to InterviewRoomHub to broadcast live transcript updates (final or interim) to other participants in the same room. The method forwards Context.ConnectionId, final/interim text and the sender's role via the ReceiveTranscript client event. A potential isRoomCompleted check is present but commented out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled real-time transcript updates to be shared with other participants within interview rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->