### PR TITLE
Implement GetSessions endpoint with pagination and filtering

### DIFF
--- a/Intervu.API/Controllers/v1/InterviewRoomController.cs
+++ b/Intervu.API/Controllers/v1/InterviewRoomController.cs
@@ -18,6 +18,7 @@ namespace Intervu.API.Controllers.v1
     public class InterviewRoomController : Controller
     {
         private readonly IGetRoomHistory _getRoomHistory;
+        private readonly IGetSessions _getSessions;
         private readonly IGetCurrentRoom _getCurrentRoom;
         private readonly IGetCoachEvaluation _getCoachEvaluation;
         private readonly ISubmitCoachEvaluation _submitCoachEvaluation;
@@ -27,6 +28,7 @@ namespace Intervu.API.Controllers.v1
 
         public InterviewRoomController(
             IGetRoomHistory getRoomHistory,
+            IGetSessions getSessions,
             IGetCurrentRoom getCurrentRoom,
             IGetCoachEvaluation getCoachEvaluation,
             ISubmitCoachEvaluation submitCoachEvaluation,
@@ -35,6 +37,7 @@ namespace Intervu.API.Controllers.v1
             IGetInterviewReports getInterviewReports)
         {
             _getRoomHistory = getRoomHistory;
+            _getSessions = getSessions;
             _getCurrentRoom = getCurrentRoom;
             _getCoachEvaluation = getCoachEvaluation;
             _submitCoachEvaluation = submitCoachEvaluation;
@@ -63,6 +66,37 @@ namespace Intervu.API.Controllers.v1
             }
 
             var result = await _getRoomHistory.ExecuteWithPaginationAsync(role, userId, request);
+
+            return Ok(new
+            {
+                success = true,
+                message = "Success",
+                data = result
+            });
+        }
+
+        /// <summary>
+        /// Get a paginated list of interview sessions for the current user.
+        /// Multi-round bookings collapse into one session; standalone rooms appear as single-round sessions.
+        /// Response includes aggregate stats and, for interviewers, a pending coach-evaluation session when present.
+        /// </summary>
+        [Authorize(Policy = AuthorizationPolicies.CandidateOrInterviewer)]
+        [HttpGet("sessions")]
+        public async Task<IActionResult> GetSessions([FromQuery] GetSessionsRequestDto request)
+        {
+            bool isGetUserIdSuccess = Guid.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out Guid userId);
+            bool isGetRoleSuccess = Enum.TryParse(User.FindFirstValue(ClaimTypes.Role), out UserRole role);
+
+            if (!isGetUserIdSuccess || !isGetRoleSuccess)
+            {
+                return Unauthorized(new
+                {
+                    success = false,
+                    message = "Invalid user credentials"
+                });
+            }
+
+            var result = await _getSessions.ExecuteAsync(role, userId, request);
 
             return Ok(new
             {

--- a/Intervu.Application/DTOs/InterviewRoom/GetSessionsRequestDto.cs
+++ b/Intervu.Application/DTOs/InterviewRoom/GetSessionsRequestDto.cs
@@ -1,0 +1,17 @@
+using Intervu.Domain.Entities.Constants;
+using System.Collections.Generic;
+
+namespace Intervu.Application.DTOs.InterviewRoom
+{
+    public class GetSessionsRequestDto
+    {
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 10;
+
+        /// <summary>
+        /// Filter sessions by the derived session status (can pass multiple).
+        /// Example: Statuses=0&amp;Statuses=1 returns sessions whose active round is Scheduled or OnGoing.
+        /// </summary>
+        public List<InterviewRoomStatus>? Statuses { get; set; }
+    }
+}

--- a/Intervu.Application/DTOs/InterviewRoom/PagedSessionsResultDto.cs
+++ b/Intervu.Application/DTOs/InterviewRoom/PagedSessionsResultDto.cs
@@ -1,0 +1,30 @@
+using Intervu.Application.DTOs.Common;
+
+namespace Intervu.Application.DTOs.InterviewRoom
+{
+    /// <summary>
+    /// Response envelope for GET /api/v1/interviewroom/sessions.
+    /// Composes a standard paged result with global stats and an optional pending-eval prompt.
+    /// </summary>
+    public class PagedSessionsResultDto
+    {
+        public PagedResult<SessionDto> Page { get; set; }
+        public SessionStatsDto Stats { get; set; }
+
+        /// <summary>
+        /// Populated for interviewer users when they have a completed room with an unfinished evaluation.
+        /// FE opens CoachEvaluationModal with this session's active room. Null otherwise.
+        /// </summary>
+        public SessionDto? PendingCoachEvaluationSession { get; set; }
+
+        public PagedSessionsResultDto(
+            PagedResult<SessionDto> page,
+            SessionStatsDto stats,
+            SessionDto? pendingCoachEvaluationSession)
+        {
+            Page = page;
+            Stats = stats;
+            PendingCoachEvaluationSession = pendingCoachEvaluationSession;
+        }
+    }
+}

--- a/Intervu.Application/DTOs/InterviewRoom/SessionDto.cs
+++ b/Intervu.Application/DTOs/InterviewRoom/SessionDto.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace Intervu.Application.DTOs.InterviewRoom
+{
+    /// <summary>
+    /// Represents an interview "session": a group of interview rooms sharing the same BookingRequestId.
+    /// Inherits every field of the active round (so FE can read room-level fields directly on the session).
+    /// Standalone rooms (no BookingRequestId) appear as single-round sessions.
+    /// </summary>
+    public class SessionDto : InterviewRoomDto
+    {
+        /// <summary>
+        /// Stable identifier: BookingRequestId when set, otherwise the single room's Id.
+        /// </summary>
+        public Guid SessionId { get; set; }
+
+        /// <summary>
+        /// 1-based index of the active round within <see cref="Rounds"/>.
+        /// Active round precedence: first OnGoing &gt; first Scheduled &gt; last by ScheduledTime.
+        /// </summary>
+        public int CurrentRound { get; set; }
+
+        /// <summary>
+        /// Number of rounds in this session (1 for standalone rooms).
+        /// </summary>
+        public int TotalRounds { get; set; }
+
+        /// <summary>
+        /// All rooms belonging to this session, sorted ascending by ScheduledTime.
+        /// </summary>
+        public List<InterviewRoomDto> Rounds { get; set; } = new();
+    }
+}

--- a/Intervu.Application/DTOs/InterviewRoom/SessionStatsDto.cs
+++ b/Intervu.Application/DTOs/InterviewRoom/SessionStatsDto.cs
@@ -1,0 +1,28 @@
+namespace Intervu.Application.DTOs.InterviewRoom
+{
+    /// <summary>
+    /// Aggregate KPIs computed across ALL of the user's sessions (ignoring the Statuses filter).
+    /// Identical for both Upcoming and Past tab requests so the UI header stays stable.
+    /// </summary>
+    public class SessionStatsDto
+    {
+        /// <summary>Sessions whose derived status is Scheduled or OnGoing.</summary>
+        public int Upcoming { get; set; }
+
+        /// <summary>Sessions whose derived status is Completed.</summary>
+        public int Completed { get; set; }
+
+        /// <summary>
+        /// Role-aware average for completed sessions, rounded to 1 dp.
+        /// Candidate: average of coach evaluation Score (scale 10).
+        /// Coach: average of candidate feedback Rating (scale 5).
+        /// Null when no evaluated rooms exist.
+        /// </summary>
+        public double? AvgScore { get; set; }
+
+        /// <summary>
+        /// Milliseconds until the earliest future Scheduled session. Null when none.
+        /// </summary>
+        public long? NextSessionInMs { get; set; }
+    }
+}

--- a/Intervu.Application/DependencyInjection.cs
+++ b/Intervu.Application/DependencyInjection.cs
@@ -116,6 +116,7 @@ namespace Intervu.Application
             services.AddScoped<ICreateInterviewRoom, CreateInterviewRoom>();
             services.AddScoped<IScheduleInterviewReminders, ScheduleInterviewReminders>();
             services.AddScoped<IGetRoomHistory, GetRoomHistory>();
+            services.AddScoped<IGetSessions, GetSessions>();
             services.AddScoped<IUpdateRoom, UpdateRoom>();
             services.AddScoped<IGetCurrentRoom, GetCurrentRoom>();
             services.AddScoped<IGetCoachEvaluation, GetCoachEvaluation>();

--- a/Intervu.Application/Interfaces/UseCases/InterviewRoom/IGetSessions.cs
+++ b/Intervu.Application/Interfaces/UseCases/InterviewRoom/IGetSessions.cs
@@ -1,0 +1,19 @@
+using Intervu.Application.DTOs.InterviewRoom;
+using Intervu.Domain.Entities.Constants;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.Interfaces.UseCases.InterviewRoom
+{
+    public interface IGetSessions
+    {
+        /// <summary>
+        /// Returns a paged list of interview sessions for the given user.
+        /// Rooms sharing the same BookingRequestId collapse into one session; standalone rooms
+        /// (no BookingRequestId) become single-round sessions keyed by the room's Id.
+        /// Includes aggregate stats over ALL user sessions and, for interviewers, a
+        /// pending coach-evaluation session when one exists.
+        /// </summary>
+        Task<PagedSessionsResultDto> ExecuteAsync(UserRole role, Guid userId, GetSessionsRequestDto request);
+    }
+}

--- a/Intervu.Application/UseCases/InterviewRoom/GetRoomHistory.cs
+++ b/Intervu.Application/UseCases/InterviewRoom/GetRoomHistory.cs
@@ -133,6 +133,8 @@ namespace Intervu.Application.UseCases.InterviewRoom
                             : null,
                     RescheduleAttemptCount = room.RescheduleAttemptCount,
                     BookingRequestId = room.BookingRequestId,
+                    JobDescriptionUrl = room.BookingRequest?.JobDescriptionUrl,
+                    CVUrl = room.BookingRequest?.CVUrl,
                     InterviewTypeName = room.CoachInterviewService?.InterviewType?.Name,
                     AimLevel = room.AimLevel,
                     RoundNumber = room.RoundNumber,

--- a/Intervu.Application/UseCases/InterviewRoom/GetSessions.cs
+++ b/Intervu.Application/UseCases/InterviewRoom/GetSessions.cs
@@ -1,0 +1,331 @@
+using Intervu.Application.DTOs.Common;
+using Intervu.Application.DTOs.InterviewRoom;
+using Intervu.Application.Interfaces.UseCases.InterviewRoom;
+using Intervu.Domain.Entities.Constants;
+using Intervu.Domain.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.InterviewRoom
+{
+    internal class GetSessions : IGetSessions
+    {
+        private readonly IInterviewRoomRepository _repo;
+        private readonly IRescheduleRequestRepository _rescheduleRepo;
+        private readonly IFeedbackRepository _feedbackRepo;
+
+        public GetSessions(
+            IInterviewRoomRepository repo,
+            IRescheduleRequestRepository rescheduleRepo,
+            IFeedbackRepository feedbackRepo)
+        {
+            _repo = repo;
+            _rescheduleRepo = rescheduleRepo;
+            _feedbackRepo = feedbackRepo;
+        }
+
+        public async Task<PagedSessionsResultDto> ExecuteAsync(
+            UserRole role,
+            Guid userId,
+            GetSessionsRequestDto request)
+        {
+            var tuples = role == UserRole.Candidate
+                ? await _repo.GetListWithNamesByCandidateIdAsync(userId)
+                : await _repo.GetListWithNamesByCoachIdAsync(userId);
+
+            var allRooms = tuples
+                .Select(t => new RoomBundle(
+                    t.Item1,
+                    t.Item2, t.Item3, t.Item4,
+                    t.Item5, t.Item6, t.Item7))
+                .ToList();
+
+            if (allRooms.Count == 0)
+            {
+                return new PagedSessionsResultDto(
+                    new PagedResult<SessionDto>(new List<SessionDto>(), 0, request.PageSize, request.Page),
+                    new SessionStatsDto(),
+                    null);
+            }
+
+            var allRoomIds = allRooms.Select(r => r.Room.Id).ToList();
+            var pendingRescheduleSet = await _rescheduleRepo.GetPendingRequestRoomIdsAsync(allRoomIds);
+            var ratingByRoomId = await _feedbackRepo.GetRatingsByInterviewRoomIdsAsync(allRoomIds);
+
+            var sessions = allRooms
+                .GroupBy(r => r.Room.BookingRequestId ?? r.Room.Id)
+                .Select(g => BuildSession(g.Key, g.ToList()))
+                .ToList();
+
+            var stats = ComputeStats(role, sessions, ratingByRoomId);
+
+            SessionDto? pendingDto = null;
+            if (role == UserRole.Coach)
+            {
+                var pendingRoom = allRooms.FirstOrDefault(r =>
+                    r.Room.Status == InterviewRoomStatus.Completed && !r.Room.IsEvaluationCompleted);
+
+                if (pendingRoom != null)
+                {
+                    var hostSession = sessions.First(s => s.Rounds.Any(rn => rn.Room.Id == pendingRoom.Room.Id));
+                    pendingDto = ProjectSession(hostSession, pendingRescheduleSet, ratingByRoomId, overrideActive: pendingRoom);
+                }
+            }
+
+            IEnumerable<Session> filtered = sessions;
+            if (request.Statuses != null && request.Statuses.Count > 0)
+            {
+                var statusSet = request.Statuses.ToHashSet();
+                filtered = filtered.Where(s => statusSet.Contains(s.Active.Room.Status));
+            }
+
+            var ordered = filtered
+                .OrderByDescending(s => s.Active.Room.ScheduledTime ?? DateTime.MinValue)
+                .ToList();
+
+            var totalItems = ordered.Count;
+
+            var pagedSessions = ordered
+                .Skip((request.Page - 1) * request.PageSize)
+                .Take(request.PageSize)
+                .ToList();
+
+            var items = pagedSessions
+                .Select(s => ProjectSession(s, pendingRescheduleSet, ratingByRoomId, overrideActive: null))
+                .ToList();
+
+            return new PagedSessionsResultDto(
+                new PagedResult<SessionDto>(items, totalItems, request.PageSize, request.Page),
+                stats,
+                pendingDto);
+        }
+
+        // ----- Helpers -----
+
+        private sealed class RoomBundle
+        {
+            public Domain.Entities.InterviewRoom Room { get; }
+            public string? CandidateName { get; }
+            public string? CandidateProfilePicture { get; }
+            public string? CandidateSlugProfileUrl { get; }
+            public string? CoachName { get; }
+            public string? CoachProfilePicture { get; }
+            public string? CoachSlugProfileUrl { get; }
+
+            public RoomBundle(
+                Domain.Entities.InterviewRoom room,
+                string? candidateName,
+                string? candidateProfilePicture,
+                string? candidateSlugProfileUrl,
+                string? coachName,
+                string? coachProfilePicture,
+                string? coachSlugProfileUrl)
+            {
+                Room = room;
+                CandidateName = candidateName;
+                CandidateProfilePicture = candidateProfilePicture;
+                CandidateSlugProfileUrl = candidateSlugProfileUrl;
+                CoachName = coachName;
+                CoachProfilePicture = coachProfilePicture;
+                CoachSlugProfileUrl = coachSlugProfileUrl;
+            }
+        }
+
+        private sealed class Session
+        {
+            public Guid SessionId { get; }
+            public List<RoomBundle> Rounds { get; }
+            public RoomBundle Active { get; }
+            public int CurrentRoundIndex { get; }
+
+            public Session(Guid sessionId, List<RoomBundle> rounds, RoomBundle active, int currentRoundIndex)
+            {
+                SessionId = sessionId;
+                Rounds = rounds;
+                Active = active;
+                CurrentRoundIndex = currentRoundIndex;
+            }
+        }
+
+        private static Session BuildSession(Guid sessionId, List<RoomBundle> group)
+        {
+            var sorted = group
+                .OrderBy(r => r.Room.ScheduledTime ?? DateTime.MinValue)
+                .ThenBy(r => r.Room.RoundNumber ?? 0)
+                .ToList();
+
+            int activeIdx = sorted.FindIndex(r => r.Room.Status == InterviewRoomStatus.Ongoing);
+            if (activeIdx < 0) activeIdx = sorted.FindIndex(r => r.Room.Status == InterviewRoomStatus.Scheduled);
+            if (activeIdx < 0) activeIdx = sorted.Count - 1;
+
+            return new Session(sessionId, sorted, sorted[activeIdx], activeIdx);
+        }
+
+        private static SessionStatsDto ComputeStats(
+            UserRole role,
+            List<Session> sessions,
+            IReadOnlyDictionary<Guid, double?> ratingByRoomId)
+        {
+            int upcoming = 0;
+            int completed = 0;
+            var scores = new List<double>();
+            DateTime? earliestFuture = null;
+            var now = DateTime.UtcNow;
+
+            foreach (var s in sessions)
+            {
+                var active = s.Active.Room;
+                switch (active.Status)
+                {
+                    case InterviewRoomStatus.Scheduled:
+                    case InterviewRoomStatus.Ongoing:
+                        upcoming++;
+                        if (active.Status == InterviewRoomStatus.Scheduled
+                            && active.ScheduledTime.HasValue
+                            && active.ScheduledTime.Value > now
+                            && (earliestFuture == null || active.ScheduledTime.Value < earliestFuture.Value))
+                        {
+                            earliestFuture = active.ScheduledTime.Value;
+                        }
+                        break;
+
+                    case InterviewRoomStatus.Completed:
+                        completed++;
+                        if (role == UserRole.Candidate)
+                        {
+                            if (active.EvaluationResults?.Any() == true)
+                            {
+                                scores.Add(active.EvaluationResults.Average(x => x.Score));
+                            }
+                        }
+                        else
+                        {
+                            if (ratingByRoomId.TryGetValue(active.Id, out var rating) && rating.HasValue)
+                            {
+                                scores.Add(rating.Value);
+                            }
+                        }
+                        break;
+                }
+            }
+
+            return new SessionStatsDto
+            {
+                Upcoming = upcoming,
+                Completed = completed,
+                AvgScore = scores.Count > 0 ? Math.Round(scores.Average(), 1) : (double?)null,
+                NextSessionInMs = earliestFuture.HasValue
+                    ? (long?)Math.Max(0, (long)(earliestFuture.Value - now).TotalMilliseconds)
+                    : null,
+            };
+        }
+
+        private static SessionDto ProjectSession(
+            Session session,
+            HashSet<Guid> pendingRescheduleSet,
+            IReadOnlyDictionary<Guid, double?> ratingByRoomId,
+            RoomBundle? overrideActive)
+        {
+            var active = overrideActive ?? session.Active;
+            var activeIdx = overrideActive != null
+                ? session.Rounds.FindIndex(r => r.Room.Id == overrideActive.Room.Id)
+                : session.CurrentRoundIndex;
+
+            var rounds = session.Rounds
+                .Select(r => ProjectRoom(r, pendingRescheduleSet, ratingByRoomId))
+                .ToList();
+
+            var activeDto = ProjectRoom(active, pendingRescheduleSet, ratingByRoomId);
+
+            return new SessionDto
+            {
+                Id = activeDto.Id,
+                CandidateId = activeDto.CandidateId,
+                CandidateName = activeDto.CandidateName,
+                CandidateProfilePicture = activeDto.CandidateProfilePicture,
+                CandidateSlugProfileUrl = activeDto.CandidateSlugProfileUrl,
+                CoachId = activeDto.CoachId,
+                CoachName = activeDto.CoachName,
+                CoachProfilePicture = activeDto.CoachProfilePicture,
+                CoachSlugProfileUrl = activeDto.CoachSlugProfileUrl,
+                ScheduledTime = activeDto.ScheduledTime,
+                DurationMinutes = activeDto.DurationMinutes,
+                VideoCallRoomUrl = activeDto.VideoCallRoomUrl,
+                CurrentLanguage = activeDto.CurrentLanguage,
+                LanguageCodes = activeDto.LanguageCodes,
+                ProblemDescription = activeDto.ProblemDescription,
+                ProblemShortName = activeDto.ProblemShortName,
+                TestCases = activeDto.TestCases,
+                Status = activeDto.Status,
+                IsEvaluationCompleted = activeDto.IsEvaluationCompleted,
+                Score = activeDto.Score,
+                Rating = activeDto.Rating,
+                RescheduleAttemptCount = activeDto.RescheduleAttemptCount,
+                Type = activeDto.Type,
+                BookingRequestId = activeDto.BookingRequestId,
+                JobDescriptionUrl = activeDto.JobDescriptionUrl,
+                CVUrl = activeDto.CVUrl,
+                InterviewTypeName = activeDto.InterviewTypeName,
+                AimLevel = activeDto.AimLevel,
+                RoundNumber = activeDto.RoundNumber,
+                HasPendingReschedule = activeDto.HasPendingReschedule,
+                CanReschedule = activeDto.CanReschedule,
+                CanCancel = activeDto.CanCancel,
+                SessionId = session.SessionId,
+                CurrentRound = activeIdx + 1,
+                TotalRounds = session.Rounds.Count,
+                Rounds = rounds,
+            };
+        }
+
+        private static InterviewRoomDto ProjectRoom(
+            RoomBundle bundle,
+            HashSet<Guid> pendingRescheduleSet,
+            IReadOnlyDictionary<Guid, double?> ratingByRoomId)
+        {
+            var room = bundle.Room;
+            var hasPendingReschedule = pendingRescheduleSet.Contains(room.Id);
+            var canReschedule = room.IsAvailableForReschedule() && !hasPendingReschedule;
+            var canCancel = room.IsAvailableForCancel();
+            ratingByRoomId.TryGetValue(room.Id, out var rating);
+
+            return new InterviewRoomDto
+            {
+                Id = room.Id,
+                CandidateId = room.CandidateId,
+                CandidateName = bundle.CandidateName,
+                CandidateProfilePicture = bundle.CandidateProfilePicture,
+                CandidateSlugProfileUrl = bundle.CandidateSlugProfileUrl,
+                CoachId = room.CoachId,
+                CoachName = bundle.CoachName,
+                CoachProfilePicture = bundle.CoachProfilePicture,
+                CoachSlugProfileUrl = bundle.CoachSlugProfileUrl,
+                ScheduledTime = room.ScheduledTime,
+                DurationMinutes = room.DurationMinutes,
+                VideoCallRoomUrl = room.VideoCallRoomUrl,
+                CurrentLanguage = room.CurrentLanguage,
+                ProblemDescription = room.ProblemDescription,
+                ProblemShortName = room.ProblemShortName,
+                Status = room.Status,
+                IsEvaluationCompleted = room.IsEvaluationCompleted,
+                Score = room.EvaluationResults?.Any() == true
+                    ? Math.Round(room.EvaluationResults.Average(x => x.Score), 1)
+                    : (double?)null,
+                Rating = rating,
+                RescheduleAttemptCount = room.RescheduleAttemptCount,
+                BookingRequestId = room.BookingRequestId,
+                JobDescriptionUrl = room.BookingRequest?.JobDescriptionUrl,
+                CVUrl = room.BookingRequest?.CVUrl,
+                InterviewTypeName = room.CoachInterviewService?.InterviewType?.Name,
+                AimLevel = room.AimLevel,
+                RoundNumber = room.RoundNumber,
+                HasPendingReschedule = hasPendingReschedule,
+                CanReschedule = canReschedule,
+                CanCancel = canCancel,
+                Type = room.Type,
+            };
+        }
+    }
+}

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/InterviewRoomRepository.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/InterviewRoomRepository.cs
@@ -38,6 +38,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL
         {
             var rooms = await _context.InterviewRooms
                 .Include(r => r.CurrentAvailability)
+                .Include(r => r.BookingRequest)
                 .Include(r => r.CoachInterviewService)!
                     .ThenInclude(s => s!.InterviewType)
                 .Where(r => r.CandidateId == candidateId)
@@ -57,6 +58,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL
         {
             var rooms = await _context.InterviewRooms
                 .Include(r => r.CurrentAvailability)
+                .Include(r => r.BookingRequest)
                 .Include(r => r.CoachInterviewService)!
                     .ThenInclude(s => s!.InterviewType)
                 .Where(r => r.CoachId == coachId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve interview sessions with pagination and filtering by session status.
  * Sessions include aggregate statistics (upcoming/completed counts, average score, and next session timing).
  * For interviewers, displays a pending coach evaluation session when a completed interview awaits feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->