### PR TITLE
feat: Add PreparedQuestions table and repository

### DIFF
--- a/Intervu.API/Controllers/v1/PreparedQuestionController.cs
+++ b/Intervu.API/Controllers/v1/PreparedQuestionController.cs
@@ -1,0 +1,185 @@
+using Asp.Versioning;
+using Intervu.API.Utils.Constant;
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Intervu.API.Controllers.v1
+{
+    /// <summary>
+    /// Coach-only endpoints for building and executing the "Prepared Questions"
+    /// roadmap attached to a specific <c>InterviewRoom</c>. All mutations are gated
+    /// on the caller being the room's assigned coach (enforced in the use cases).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/prepared-questions")]
+    public class PreparedQuestionController : ControllerBase
+    {
+        private readonly IGetPreparedQuestions _get;
+        private readonly IAddCustomPreparedQuestion _addCustom;
+        private readonly IAddPreparedQuestionFromBank _addFromBank;
+        private readonly IUpdatePreparedQuestion _update;
+        private readonly IDeletePreparedQuestion _delete;
+        private readonly IReorderPreparedQuestions _reorder;
+        private readonly IMarkPreparedQuestionAsked _markAsked;
+        private readonly IUnmarkPreparedQuestionAsked _unmarkAsked;
+        private readonly ISendPreparedQuestionToEditor _sendToEditor;
+
+        public PreparedQuestionController(
+            IGetPreparedQuestions get,
+            IAddCustomPreparedQuestion addCustom,
+            IAddPreparedQuestionFromBank addFromBank,
+            IUpdatePreparedQuestion update,
+            IDeletePreparedQuestion delete,
+            IReorderPreparedQuestions reorder,
+            IMarkPreparedQuestionAsked markAsked,
+            IUnmarkPreparedQuestionAsked unmarkAsked,
+            ISendPreparedQuestionToEditor sendToEditor)
+        {
+            _get = get;
+            _addCustom = addCustom;
+            _addFromBank = addFromBank;
+            _update = update;
+            _delete = delete;
+            _reorder = reorder;
+            _markAsked = markAsked;
+            _unmarkAsked = unmarkAsked;
+            _sendToEditor = sendToEditor;
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpGet("rooms/{roomId}")]
+        public async Task<IActionResult> GetByRoom(Guid roomId)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            var data = await _get.ExecuteAsync(roomId, userId);
+            return Ok(new { success = true, message = "Success", data });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpPost("rooms/{roomId}/custom")]
+        public async Task<IActionResult> AddCustom(
+            Guid roomId,
+            [FromBody] CreateCustomPreparedQuestionRequest request)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            var data = await _addCustom.ExecuteAsync(roomId, request, userId);
+            return Ok(new { success = true, message = "Prepared question added", data });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpPost("rooms/{roomId}/from-bank")]
+        public async Task<IActionResult> AddFromBank(
+            Guid roomId,
+            [FromBody] ImportBankQuestionRequest request)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            var data = await _addFromBank.ExecuteAsync(roomId, request, userId);
+            return Ok(new { success = true, message = "Bank question imported", data });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpPut("{preparedQuestionId}")]
+        public async Task<IActionResult> Update(
+            Guid preparedQuestionId,
+            [FromBody] UpdatePreparedQuestionRequest request)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            var data = await _update.ExecuteAsync(preparedQuestionId, request, userId);
+            return Ok(new { success = true, message = "Prepared question updated", data });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpDelete("{preparedQuestionId}")]
+        public async Task<IActionResult> Delete(Guid preparedQuestionId)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            await _delete.ExecuteAsync(preparedQuestionId, userId);
+            return Ok(new { success = true, message = "Prepared question removed" });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpPut("rooms/{roomId}/reorder")]
+        public async Task<IActionResult> Reorder(
+            Guid roomId,
+            [FromBody] ReorderPreparedQuestionsRequest request)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            await _reorder.ExecuteAsync(roomId, request, userId);
+            return Ok(new { success = true, message = "Prepared questions reordered" });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpPut("{preparedQuestionId}/mark-asked")]
+        public async Task<IActionResult> MarkAsked(Guid preparedQuestionId)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            var data = await _markAsked.ExecuteAsync(preparedQuestionId, userId);
+            return Ok(new { success = true, message = "Marked as asked", data });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpPut("{preparedQuestionId}/unmark-asked")]
+        public async Task<IActionResult> UnmarkAsked(Guid preparedQuestionId)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            var data = await _unmarkAsked.ExecuteAsync(preparedQuestionId, userId);
+            return Ok(new { success = true, message = "Unmarked", data });
+        }
+
+        [Authorize(Policy = AuthorizationPolicies.Interviewer)]
+        [HttpPut("{preparedQuestionId}/send-to-editor")]
+        public async Task<IActionResult> SendToEditor(Guid preparedQuestionId)
+        {
+            if (!TryGetUserId(out var userId))
+            {
+                return Unauthorized(new { success = false, message = "Invalid user credentials" });
+            }
+
+            var data = await _sendToEditor.ExecuteAsync(preparedQuestionId, userId);
+            return Ok(new { success = true, message = "Sent to editor", data });
+        }
+
+        private bool TryGetUserId(out Guid userId)
+        {
+            return Guid.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out userId);
+        }
+    }
+}

--- a/Intervu.API/Program.cs
+++ b/Intervu.API/Program.cs
@@ -110,6 +110,7 @@ namespace Intervu.API
 
             // Notification real-time push
             builder.Services.AddScoped<Intervu.Application.Interfaces.ExternalServices.INotificationPusher, Intervu.API.Services.SignalRNotificationPusher>();
+            builder.Services.AddScoped<Intervu.Application.Interfaces.ExternalServices.IInterviewRoomRealtimePusher, Intervu.API.Services.InterviewRoomRealtimePusher>();
 
             // --- AUTHENTICATION WITH JWT CONFIGURATION ---
             builder.Services.AddAuthentication(options =>

--- a/Intervu.API/Services/InterviewRoomRealtimePusher.cs
+++ b/Intervu.API/Services/InterviewRoomRealtimePusher.cs
@@ -1,0 +1,127 @@
+using Intervu.API.Hubs;
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Interfaces.ExternalServices;
+using Intervu.Application.Services;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Intervu.API.Services
+{
+    /// <summary>
+    /// SignalR-backed implementation of <see cref="IInterviewRoomRealtimePusher"/>.
+    /// Sits alongside <see cref="SignalRNotificationPusher"/> but targets
+    /// InterviewRoomHub groups (keyed by roomId) rather than per-user groups.
+    ///
+    /// For "Send to Editor" we intentionally mirror the existing
+    /// <c>InterviewRoomHub.SendProblem</c> flow — broadcast the problem,
+    /// sync the in-memory <see cref="RoomState"/>, regenerate the starter
+    /// code template for the current language, and broadcast
+    /// <c>ReceiveCode</c> so the candidate's Monaco editor actually picks up
+    /// the new function-name / test-case signature. Without the template
+    /// regeneration the editor keeps the old code and appears "unchanged".
+    /// </summary>
+    public class InterviewRoomRealtimePusher : IInterviewRoomRealtimePusher
+    {
+        private readonly IHubContext<InterviewRoomHub> _hubContext;
+        private readonly RoomManagerService _roomManager;
+        private readonly IReadOnlyDictionary<string, ICodeGenerationService> _codeGenerationServices;
+        private readonly ILogger<InterviewRoomRealtimePusher> _logger;
+
+        public InterviewRoomRealtimePusher(
+            IHubContext<InterviewRoomHub> hubContext,
+            RoomManagerService roomManager,
+            IEnumerable<ICodeGenerationService> codeGenerationServices,
+            ILogger<InterviewRoomRealtimePusher> logger)
+        {
+            _hubContext = hubContext;
+            _roomManager = roomManager;
+            _codeGenerationServices = codeGenerationServices
+                .ToDictionary(s => s.Language, StringComparer.OrdinalIgnoreCase);
+            _logger = logger;
+        }
+
+        public async Task PushPreparedQuestionStatusChangedAsync(Guid interviewRoomId, PreparedQuestionDto dto)
+        {
+            await _hubContext.Clients.Group(interviewRoomId.ToString())
+                .SendAsync("PreparedQuestionStatusChanged", dto);
+        }
+
+        public async Task PushProblemToRoomAsync(
+            Guid interviewRoomId,
+            Guid? excludeUserId,
+            string description,
+            string shortName,
+            object[] testCases)
+        {
+            var roomIdStr = interviewRoomId.ToString();
+            var groupClients = _hubContext.Clients.Group(roomIdStr);
+
+            // 1) Same payload shape as InterviewRoomHub.SendProblem -> "ReceiveProblem",
+            //    so the existing candidate frontend handler works unchanged.
+            await groupClients.SendAsync("ReceiveProblem", description, shortName, testCases);
+
+            // 2) Keep the in-memory RoomState in sync with what we just broadcast.
+            //    Late-joiners get this via ReceiveFullState on connect.
+            RoomState? roomState = null;
+            try
+            {
+                roomState = await _roomManager.GetOrCreateRoomStateAsync(roomIdStr);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "RoomManager lookup failed for {RoomId} during Send-to-Editor broadcast",
+                    roomIdStr);
+            }
+
+            if (roomState == null)
+            {
+                return;
+            }
+
+            roomState.ProblemDescription = description ?? string.Empty;
+            roomState.ProblemShortName = shortName ?? string.Empty;
+            roomState.TestCases = testCases ?? Array.Empty<object>();
+
+            // 3) Regenerate the Monaco starter-code template for the current language.
+            //    This is the same branch InterviewRoomHub.SendProblem runs — without
+            //    it, the editor keeps the previous code and the "no change" symptom
+            //    appears even though ReceiveProblem arrived correctly.
+            if (string.IsNullOrEmpty(shortName)
+                || testCases == null
+                || testCases.Length == 0)
+            {
+                return;
+            }
+
+            var language = roomState.CurrentLanguage;
+            if (string.IsNullOrEmpty(language)
+                || !_codeGenerationServices.TryGetValue(language, out var codeGenService))
+            {
+                return;
+            }
+
+            try
+            {
+                var generatedCode = codeGenService.GenerateTemplate(shortName, testCases);
+                if (string.IsNullOrEmpty(generatedCode))
+                {
+                    return;
+                }
+
+                roomState.LanguageCodes[language] = generatedCode;
+                await groupClients.SendAsync("ReceiveCode", generatedCode, language);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Starter-code generation failed for room {RoomId}, language {Language}",
+                    roomIdStr, language);
+            }
+        }
+    }
+}

--- a/Intervu.Application/DTOs/PreparedQuestion/PreparedQuestionDtos.cs
+++ b/Intervu.Application/DTOs/PreparedQuestion/PreparedQuestionDtos.cs
@@ -1,0 +1,88 @@
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Intervu.Application.DTOs.PreparedQuestion
+{
+    public class PreparedQuestionDto
+    {
+        public Guid Id { get; set; }
+        public Guid InterviewRoomId { get; set; }
+        public Guid CreatedBy { get; set; }
+        public Guid? SourceBankQuestionId { get; set; }
+
+        public PreparedQuestionInteractionType InteractionType { get; set; }
+        public string? DisplayCategoryLabel { get; set; }
+
+        public string Title { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+
+        public string? FunctionName { get; set; }
+        public object[]? TestCases { get; set; }
+
+        public PreparedQuestionStatus Status { get; set; }
+        public DateTime? AskedAt { get; set; }
+        public int SortOrder { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+
+        /// <summary>
+        /// True when the question can be sent to the candidate's editor.
+        /// Always true for NonCoding. For Coding, requires FunctionName AND >= 1 TestCase.
+        /// </summary>
+        public bool IsReadyForEditor { get; set; }
+    }
+
+    public class CreateCustomPreparedQuestionRequest
+    {
+        [Required]
+        public PreparedQuestionInteractionType InteractionType { get; set; }
+
+        [Required]
+        [MaxLength(500)]
+        public string Title { get; set; } = string.Empty;
+
+        [Required]
+        public string Description { get; set; } = string.Empty;
+
+        [MaxLength(100)]
+        public string? DisplayCategoryLabel { get; set; }
+
+        [MaxLength(200)]
+        public string? FunctionName { get; set; }
+
+        public object[]? TestCases { get; set; }
+    }
+
+    public class ImportBankQuestionRequest
+    {
+        [Required]
+        public Guid BankQuestionId { get; set; }
+    }
+
+    public class UpdatePreparedQuestionRequest
+    {
+        [Required]
+        [MaxLength(500)]
+        public string Title { get; set; } = string.Empty;
+
+        [Required]
+        public string Description { get; set; } = string.Empty;
+
+        [MaxLength(100)]
+        public string? DisplayCategoryLabel { get; set; }
+
+        [MaxLength(200)]
+        public string? FunctionName { get; set; }
+
+        public object[]? TestCases { get; set; }
+    }
+
+    public class ReorderPreparedQuestionsRequest
+    {
+        [Required]
+        public List<Guid> OrderedIds { get; set; } = new();
+    }
+}

--- a/Intervu.Application/DependencyInjection.cs
+++ b/Intervu.Application/DependencyInjection.cs
@@ -59,6 +59,8 @@ using Intervu.Application.Interfaces.UseCases.SmartSearch;
 using Intervu.Application.UseCases.SmartSearch;
 using Intervu.Application.Interfaces.UseCases.GeneratedQuestion;
 using Intervu.Application.UseCases.GeneratedQuestion;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using PreparedQuestionUseCases = Intervu.Application.UseCases.PreparedQuestion;
 using Intervu.Application.Interfaces.UseCases.Audit;
 using Intervu.Application.UseCases.Audit;
 using CoachDashboardInterfaces = Intervu.Application.Interfaces.UseCases.CoachDashboard;
@@ -244,6 +246,17 @@ namespace Intervu.Application
             services.AddScoped<IApproveGeneratedQuestion, ApproveGeneratedQuestion>();
             services.AddScoped<IRejectGeneratedQuestion, RejectGeneratedQuestion>();
             services.AddScoped<ICreateGeneratedQuestion, CreateGeneratedQuestion>();
+
+            // --- Prepared Questions (pre-interview roadmap + in-room execution) ---
+            services.AddScoped<IGetPreparedQuestions, PreparedQuestionUseCases.GetPreparedQuestions>();
+            services.AddScoped<IAddCustomPreparedQuestion, PreparedQuestionUseCases.AddCustomPreparedQuestion>();
+            services.AddScoped<IAddPreparedQuestionFromBank, PreparedQuestionUseCases.AddPreparedQuestionFromBank>();
+            services.AddScoped<IUpdatePreparedQuestion, PreparedQuestionUseCases.UpdatePreparedQuestion>();
+            services.AddScoped<IDeletePreparedQuestion, PreparedQuestionUseCases.DeletePreparedQuestion>();
+            services.AddScoped<IReorderPreparedQuestions, PreparedQuestionUseCases.ReorderPreparedQuestions>();
+            services.AddScoped<IMarkPreparedQuestionAsked, PreparedQuestionUseCases.MarkPreparedQuestionAsked>();
+            services.AddScoped<IUnmarkPreparedQuestionAsked, PreparedQuestionUseCases.UnmarkPreparedQuestionAsked>();
+            services.AddScoped<ISendPreparedQuestionToEditor, PreparedQuestionUseCases.SendPreparedQuestionToEditor>();
 
             // --- Comments ---
             services.AddScoped<IGetComments, GetComments>();

--- a/Intervu.Application/Interfaces/ExternalServices/IInterviewRoomRealtimePusher.cs
+++ b/Intervu.Application/Interfaces/ExternalServices/IInterviewRoomRealtimePusher.cs
@@ -1,0 +1,35 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.Interfaces.ExternalServices
+{
+    /// <summary>
+    /// Thin abstraction over the InterviewRoomHub SignalR broadcaster so use cases
+    /// can stay decoupled from the API/Hub layer. Each method is a best-effort push
+    /// to all connected clients in the given room group; failures should be logged
+    /// but MUST NOT abort the calling business operation.
+    /// </summary>
+    public interface IInterviewRoomRealtimePusher
+    {
+        /// <summary>
+        /// Broadcasts a status change for one prepared question to every client in
+        /// the room. The candidate peer ignores it (UI-gated); the coach uses it to
+        /// sync Workspace state across their own tabs/devices.
+        /// </summary>
+        Task PushPreparedQuestionStatusChangedAsync(Guid interviewRoomId, PreparedQuestionDto dto);
+
+        /// <summary>
+        /// Mirrors InterviewRoomHub.SendProblem: pushes the problem description,
+        /// short name and test cases to the room (excluding the caller). Used by
+        /// "Send to Editor" so the candidate's Monaco editor and problem description
+        /// panel update in real time.
+        /// </summary>
+        Task PushProblemToRoomAsync(
+            Guid interviewRoomId,
+            Guid? excludeUserId,
+            string description,
+            string shortName,
+            object[] testCases);
+    }
+}

--- a/Intervu.Application/Interfaces/UseCases/PreparedQuestion/IPreparedQuestionUseCases.cs
+++ b/Intervu.Application/Interfaces/UseCases/PreparedQuestion/IPreparedQuestionUseCases.cs
@@ -1,0 +1,64 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.Interfaces.UseCases.PreparedQuestion
+{
+    public interface IGetPreparedQuestions
+    {
+        Task<List<PreparedQuestionDto>> ExecuteAsync(Guid interviewRoomId, Guid userId);
+    }
+
+    public interface IAddCustomPreparedQuestion
+    {
+        Task<PreparedQuestionDto> ExecuteAsync(
+            Guid interviewRoomId,
+            CreateCustomPreparedQuestionRequest request,
+            Guid userId);
+    }
+
+    public interface IAddPreparedQuestionFromBank
+    {
+        Task<PreparedQuestionDto> ExecuteAsync(
+            Guid interviewRoomId,
+            ImportBankQuestionRequest request,
+            Guid userId);
+    }
+
+    public interface IUpdatePreparedQuestion
+    {
+        Task<PreparedQuestionDto> ExecuteAsync(
+            Guid preparedQuestionId,
+            UpdatePreparedQuestionRequest request,
+            Guid userId);
+    }
+
+    public interface IDeletePreparedQuestion
+    {
+        Task ExecuteAsync(Guid preparedQuestionId, Guid userId);
+    }
+
+    public interface IReorderPreparedQuestions
+    {
+        Task ExecuteAsync(
+            Guid interviewRoomId,
+            ReorderPreparedQuestionsRequest request,
+            Guid userId);
+    }
+
+    public interface IMarkPreparedQuestionAsked
+    {
+        Task<PreparedQuestionDto> ExecuteAsync(Guid preparedQuestionId, Guid userId);
+    }
+
+    public interface IUnmarkPreparedQuestionAsked
+    {
+        Task<PreparedQuestionDto> ExecuteAsync(Guid preparedQuestionId, Guid userId);
+    }
+
+    public interface ISendPreparedQuestionToEditor
+    {
+        Task<PreparedQuestionDto> ExecuteAsync(Guid preparedQuestionId, Guid userId);
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/AddCustomPreparedQuestion.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/AddCustomPreparedQuestion.cs
@@ -1,0 +1,80 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Repositories;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class AddCustomPreparedQuestion(IUnitOfWork unitOfWork) : IAddCustomPreparedQuestion
+    {
+        public async Task<PreparedQuestionDto> ExecuteAsync(
+            Guid interviewRoomId,
+            CreateCustomPreparedQuestionRequest request,
+            Guid userId)
+        {
+            if (request == null)
+            {
+                throw new BadRequestException("Request body is required");
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Title))
+            {
+                throw new BadRequestException("Title is required");
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Description))
+            {
+                throw new BadRequestException("Description is required");
+            }
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(roomRepo, interviewRoomId, userId);
+
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+            var nextSortOrder = await preparedRepo.GetMaxSortOrderAsync(interviewRoomId) + 1;
+
+            var now = DateTime.UtcNow;
+            var entity = new Domain.Entities.PreparedQuestion
+            {
+                Id = Guid.NewGuid(),
+                InterviewRoomId = interviewRoomId,
+                CreatedBy = userId,
+                SourceBankQuestionId = null,
+                InteractionType = request.InteractionType,
+                DisplayCategoryLabel = NormalizeLabel(request.DisplayCategoryLabel, request.InteractionType),
+                Title = request.Title.Trim(),
+                Description = request.Description,
+                FunctionName = request.InteractionType == PreparedQuestionInteractionType.Coding
+                    ? request.FunctionName?.Trim()
+                    : null,
+                TestCases = request.InteractionType == PreparedQuestionInteractionType.Coding
+                    ? PreparedQuestionMapper.NormalizeTestCasesForPersistence(request.TestCases)
+                    : null,
+                Status = PreparedQuestionStatus.Pending,
+                AskedAt = null,
+                SortOrder = nextSortOrder,
+                CreatedAt = now,
+                UpdatedAt = now
+            };
+
+            await preparedRepo.AddAsync(entity);
+            await unitOfWork.SaveChangesAsync();
+
+            return PreparedQuestionMapper.ToDto(entity);
+        }
+
+        private static string NormalizeLabel(string? incoming, PreparedQuestionInteractionType interactionType)
+        {
+            if (!string.IsNullOrWhiteSpace(incoming))
+            {
+                return incoming.Trim();
+            }
+
+            return interactionType == PreparedQuestionInteractionType.Coding ? "Coding" : "Behavioral";
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/AddPreparedQuestionFromBank.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/AddPreparedQuestionFromBank.cs
@@ -1,0 +1,71 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Repositories;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class AddPreparedQuestionFromBank(IUnitOfWork unitOfWork) : IAddPreparedQuestionFromBank
+    {
+        public async Task<PreparedQuestionDto> ExecuteAsync(
+            Guid interviewRoomId,
+            ImportBankQuestionRequest request,
+            Guid userId)
+        {
+            if (request == null || request.BankQuestionId == Guid.Empty)
+            {
+                throw new BadRequestException("bankQuestionId is required");
+            }
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(roomRepo, interviewRoomId, userId);
+
+            var questionRepo = unitOfWork.GetRepository<IQuestionRepository>();
+            var bankQuestion = await questionRepo.GetByIdAsync(request.BankQuestionId)
+                ?? throw new NotFoundException("Bank question not found");
+
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+
+            var existing = await preparedRepo.FindByRoomAndBankQuestionAsync(interviewRoomId, bankQuestion.Id);
+            if (existing != null)
+            {
+                throw new ConflictException("This bank question has already been added to the roadmap");
+            }
+
+            var nextSortOrder = await preparedRepo.GetMaxSortOrderAsync(interviewRoomId) + 1;
+            var interactionType = PreparedQuestionMapper.MapBankToInteractionType(
+                bankQuestion.Category, bankQuestion.Round);
+
+            var now = DateTime.UtcNow;
+            var entity = new Domain.Entities.PreparedQuestion
+            {
+                Id = Guid.NewGuid(),
+                InterviewRoomId = interviewRoomId,
+                CreatedBy = userId,
+                SourceBankQuestionId = bankQuestion.Id,
+                InteractionType = interactionType,
+                DisplayCategoryLabel = PreparedQuestionMapper.MapBankCategoryToLabel(bankQuestion.Category),
+                Title = bankQuestion.Title,
+                Description = bankQuestion.Content,
+                // Bank questions don't carry a function name / test cases; the coach
+                // completes those fields before "Send to Editor" becomes available.
+                FunctionName = null,
+                TestCases = null,
+                Status = PreparedQuestionStatus.Pending,
+                AskedAt = null,
+                SortOrder = nextSortOrder,
+                CreatedAt = now,
+                UpdatedAt = now
+            };
+
+            await preparedRepo.AddAsync(entity);
+            await unitOfWork.SaveChangesAsync();
+
+            return PreparedQuestionMapper.ToDto(entity);
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/DeletePreparedQuestion.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/DeletePreparedQuestion.cs
@@ -1,0 +1,34 @@
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Repositories;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class DeletePreparedQuestion(IUnitOfWork unitOfWork) : IDeletePreparedQuestion
+    {
+        public async Task ExecuteAsync(Guid preparedQuestionId, Guid userId)
+        {
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+            var entity = await preparedRepo.GetByIdAsync(preparedQuestionId)
+                ?? throw new NotFoundException("Prepared question not found");
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(roomRepo, entity.InterviewRoomId, userId);
+
+            // Preserve audit trail: once a question has been asked in the live room we
+            // don't allow hard deletes from the Workspace. Coaches can un-mark instead.
+            if (entity.Status == PreparedQuestionStatus.Asked)
+            {
+                throw new ConflictException(
+                    "This question has already been asked. Unmark it before removing it from the list.");
+            }
+
+            preparedRepo.DeleteAsync(entity);
+            await unitOfWork.SaveChangesAsync();
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/GetPreparedQuestions.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/GetPreparedQuestions.cs
@@ -1,0 +1,24 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class GetPreparedQuestions(
+        IPreparedQuestionRepository preparedQuestionRepository,
+        IInterviewRoomRepository interviewRoomRepository) : IGetPreparedQuestions
+    {
+        public async Task<List<PreparedQuestionDto>> ExecuteAsync(Guid interviewRoomId, Guid userId)
+        {
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(
+                interviewRoomRepository, interviewRoomId, userId);
+
+            var items = await preparedQuestionRepository.GetByInterviewRoomIdAsync(interviewRoomId);
+            return items.Select(PreparedQuestionMapper.ToDto).ToList();
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/MarkPreparedQuestionAsked.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/MarkPreparedQuestionAsked.cs
@@ -1,0 +1,59 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.ExternalServices;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class MarkPreparedQuestionAsked(
+        IUnitOfWork unitOfWork,
+        IInterviewRoomRealtimePusher pusher,
+        ILogger<MarkPreparedQuestionAsked> logger) : IMarkPreparedQuestionAsked
+    {
+        public async Task<PreparedQuestionDto> ExecuteAsync(Guid preparedQuestionId, Guid userId)
+        {
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+            var entity = await preparedRepo.GetByIdAsync(preparedQuestionId)
+                ?? throw new NotFoundException("Prepared question not found");
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(roomRepo, entity.InterviewRoomId, userId);
+
+            if (entity.Status == PreparedQuestionStatus.Asked)
+            {
+                // Idempotent: return the existing state rather than error.
+                return PreparedQuestionMapper.ToDto(entity);
+            }
+
+            entity.Status = PreparedQuestionStatus.Asked;
+            entity.AskedAt = DateTime.UtcNow;
+            entity.UpdatedAt = entity.AskedAt.Value;
+
+            preparedRepo.UpdateAsync(entity);
+            await unitOfWork.SaveChangesAsync();
+
+            var dto = PreparedQuestionMapper.ToDto(entity);
+
+            // Best-effort realtime notify so the coach's other tabs sync. Never block
+            // the API response on a SignalR hiccup.
+            try
+            {
+                await pusher.PushPreparedQuestionStatusChangedAsync(entity.InterviewRoomId, dto);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to push PreparedQuestionStatusChanged for {PreparedQuestionId}",
+                    preparedQuestionId);
+            }
+
+            return dto;
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/PreparedQuestionMapper.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/PreparedQuestionMapper.cs
@@ -1,0 +1,126 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Entities.Constants.QuestionConstants;
+using Intervu.Domain.Repositories;
+using System;
+using System.Threading.Tasks;
+using InterviewRoomEntity = Intervu.Domain.Entities.InterviewRoom;
+using NewtonsoftJson = Newtonsoft.Json.JsonConvert;
+using SystemTextJson = System.Text.Json.JsonSerializer;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    internal static class PreparedQuestionMapper
+    {
+        public static PreparedQuestionDto ToDto(Domain.Entities.PreparedQuestion pq)
+        {
+            return new PreparedQuestionDto
+            {
+                Id = pq.Id,
+                InterviewRoomId = pq.InterviewRoomId,
+                CreatedBy = pq.CreatedBy,
+                SourceBankQuestionId = pq.SourceBankQuestionId,
+                InteractionType = pq.InteractionType,
+                DisplayCategoryLabel = pq.DisplayCategoryLabel,
+                Title = pq.Title,
+                Description = pq.Description,
+                FunctionName = pq.FunctionName,
+                TestCases = pq.TestCases,
+                Status = pq.Status,
+                AskedAt = pq.AskedAt,
+                SortOrder = pq.SortOrder,
+                CreatedAt = pq.CreatedAt,
+                UpdatedAt = pq.UpdatedAt,
+                IsReadyForEditor = pq.IsReadyForEditor()
+            };
+        }
+
+        /// <summary>
+        /// Maps a Question-bank Category/Round onto our binary interaction type.
+        /// Anything not explicitly Coding is treated as NonCoding.
+        /// </summary>
+        public static PreparedQuestionInteractionType MapBankToInteractionType(
+            QuestionCategory category,
+            Domain.Entities.Constants.QuestionConstants.InterviewRound round)
+        {
+            if (category == QuestionCategory.Coding
+                || round == Domain.Entities.Constants.QuestionConstants.InterviewRound.CodingChallenge
+                || round == Domain.Entities.Constants.QuestionConstants.InterviewRound.LiveCoding)
+            {
+                return PreparedQuestionInteractionType.Coding;
+            }
+
+            return PreparedQuestionInteractionType.NonCoding;
+        }
+
+        /// <summary>
+        /// Normalises a raw <c>object[]</c> test-case payload into a shape that the
+        /// EF Core <see cref="System.Text.Json.JsonSerializer"/>-based value converter
+        /// can persist cleanly.
+        ///
+        /// Why this exists: the API layer uses <c>AddNewtonsoftJson</c>, so request
+        /// bodies deserialize each untyped <c>object</c> into a Newtonsoft
+        /// <c>JObject</c>. When we then hand that straight to the entity property
+        /// and EF serialises it with <c>System.Text.Json</c>, STJ has no converter
+        /// for <c>JObject</c> and emits either empty objects or the CLR-property
+        /// projection of <c>JObject</c> — which is how Coding test cases end up
+        /// "disappearing" by the time the question is sent to the editor.
+        ///
+        /// We re-serialise through Newtonsoft (which preserves the wire JSON 1:1)
+        /// and reparse with <c>System.Text.Json</c> so the entity holds
+        /// <c>JsonElement[]</c>, which STJ serialises losslessly on save and on
+        /// every SignalR broadcast afterwards.
+        /// </summary>
+        public static object[]? NormalizeTestCasesForPersistence(object[]? raw)
+        {
+            if (raw == null || raw.Length == 0)
+            {
+                return null;
+            }
+
+            var json = NewtonsoftJson.SerializeObject(raw);
+            return SystemTextJson.Deserialize<object[]>(json);
+        }
+
+        /// <summary>
+        /// Humanised label for the bank category. Preserves the original category string
+        /// (e.g. "Behavioral", "Technical", "SystemDesign"), which the UI displays as a chip.
+        /// </summary>
+        public static string MapBankCategoryToLabel(QuestionCategory category)
+        {
+            return category switch
+            {
+                QuestionCategory.SystemDesign => "System Design",
+                QuestionCategory.DataStructures => "Data Structures",
+                QuestionCategory.CaseStudy => "Case Study",
+                QuestionCategory.DistributedSystems => "Distributed Systems",
+                _ => category.ToString()
+            };
+        }
+    }
+
+    internal static class PreparedQuestionAuthorization
+    {
+        /// <summary>
+        /// Loads the room and validates that the caller is its assigned Coach.
+        /// Throws NotFoundException if the room does not exist,
+        /// or ForbiddenException if the caller isn't the room's coach.
+        /// </summary>
+        public static async Task<InterviewRoomEntity> EnsureRoomCoachAsync(
+            IInterviewRoomRepository roomRepo,
+            Guid interviewRoomId,
+            Guid userId)
+        {
+            var room = await roomRepo.GetByIdAsync(interviewRoomId)
+                ?? throw new NotFoundException("Interview room not found");
+
+            if (!room.CoachId.HasValue || room.CoachId.Value != userId)
+            {
+                throw new ForbiddenException("Only the assigned coach can manage prepared questions for this room");
+            }
+
+            return room;
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/ReorderPreparedQuestions.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/ReorderPreparedQuestions.cs
@@ -1,0 +1,56 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Repositories;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class ReorderPreparedQuestions(IUnitOfWork unitOfWork) : IReorderPreparedQuestions
+    {
+        public async Task ExecuteAsync(
+            Guid interviewRoomId,
+            ReorderPreparedQuestionsRequest request,
+            Guid userId)
+        {
+            if (request == null || request.OrderedIds == null || request.OrderedIds.Count == 0)
+            {
+                throw new BadRequestException("orderedIds is required");
+            }
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(roomRepo, interviewRoomId, userId);
+
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+
+            // Load every row owned by the room; we only reorder rows supplied in the
+            // payload and leave any others untouched (in case the client is stale).
+            var allInRoom = await preparedRepo.GetByInterviewRoomIdAsync(interviewRoomId);
+            var lookup = allInRoom.ToDictionary(x => x.Id);
+
+            var now = DateTime.UtcNow;
+            var sortOrder = 0;
+            foreach (var id in request.OrderedIds.Distinct())
+            {
+                if (!lookup.TryGetValue(id, out var entity))
+                {
+                    continue;
+                }
+
+                if (entity.SortOrder != sortOrder)
+                {
+                    entity.SortOrder = sortOrder;
+                    entity.UpdatedAt = now;
+                    preparedRepo.UpdateAsync(entity);
+                }
+
+                sortOrder++;
+            }
+
+            await unitOfWork.SaveChangesAsync();
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/SendPreparedQuestionToEditor.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/SendPreparedQuestionToEditor.cs
@@ -1,0 +1,96 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.ExternalServices;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class SendPreparedQuestionToEditor(
+        IUnitOfWork unitOfWork,
+        IInterviewRoomRealtimePusher pusher,
+        ILogger<SendPreparedQuestionToEditor> logger) : ISendPreparedQuestionToEditor
+    {
+        public async Task<PreparedQuestionDto> ExecuteAsync(Guid preparedQuestionId, Guid userId)
+        {
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+            var entity = await preparedRepo.GetByIdAsync(preparedQuestionId)
+                ?? throw new NotFoundException("Prepared question not found");
+
+            if (entity.InteractionType != PreparedQuestionInteractionType.Coding)
+            {
+                throw new BadRequestException(
+                    "Only coding questions can be sent to the editor. Use Mark as Asked for behavioral questions.");
+            }
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            var room = await PreparedQuestionAuthorization.EnsureRoomCoachAsync(
+                roomRepo, entity.InterviewRoomId, userId);
+
+            if (!entity.IsReadyForEditor())
+            {
+                throw new BadRequestException(
+                    "Coding question is incomplete. Add a function name and at least one test case before sending.");
+            }
+
+            var now = DateTime.UtcNow;
+            var testCases = entity.TestCases ?? Array.Empty<object>();
+
+            // Mirror the in-room QuestionPanel "Set Problem" flow: persist the room
+            // problem fields so the candidate's next reconnect restores the same state.
+            room.ProblemDescription = entity.Description;
+            room.ProblemShortName = entity.FunctionName;
+            room.TestCases = testCases;
+            roomRepo.UpdateAsync(room);
+
+            if (entity.Status != PreparedQuestionStatus.Asked)
+            {
+                entity.Status = PreparedQuestionStatus.Asked;
+                entity.AskedAt = now;
+            }
+            entity.UpdatedAt = now;
+            preparedRepo.UpdateAsync(entity);
+
+            await unitOfWork.SaveChangesAsync();
+
+            var dto = PreparedQuestionMapper.ToDto(entity);
+
+            // Push ReceiveProblem + PreparedQuestionStatusChanged. Failures here are
+            // logged but MUST NOT roll back the database change – the coach can re-send
+            // from the Workspace if the broadcast drops.
+            try
+            {
+                await pusher.PushProblemToRoomAsync(
+                    entity.InterviewRoomId,
+                    excludeUserId: userId,
+                    description: entity.Description,
+                    shortName: entity.FunctionName ?? string.Empty,
+                    testCases: testCases);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to broadcast ReceiveProblem for {PreparedQuestionId}",
+                    preparedQuestionId);
+            }
+
+            try
+            {
+                await pusher.PushPreparedQuestionStatusChangedAsync(entity.InterviewRoomId, dto);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to push PreparedQuestionStatusChanged (send-to-editor) for {PreparedQuestionId}",
+                    preparedQuestionId);
+            }
+
+            return dto;
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/UnmarkPreparedQuestionAsked.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/UnmarkPreparedQuestionAsked.cs
@@ -1,0 +1,56 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.ExternalServices;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class UnmarkPreparedQuestionAsked(
+        IUnitOfWork unitOfWork,
+        IInterviewRoomRealtimePusher pusher,
+        ILogger<UnmarkPreparedQuestionAsked> logger) : IUnmarkPreparedQuestionAsked
+    {
+        public async Task<PreparedQuestionDto> ExecuteAsync(Guid preparedQuestionId, Guid userId)
+        {
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+            var entity = await preparedRepo.GetByIdAsync(preparedQuestionId)
+                ?? throw new NotFoundException("Prepared question not found");
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(roomRepo, entity.InterviewRoomId, userId);
+
+            if (entity.Status == PreparedQuestionStatus.Pending)
+            {
+                return PreparedQuestionMapper.ToDto(entity);
+            }
+
+            entity.Status = PreparedQuestionStatus.Pending;
+            entity.AskedAt = null;
+            entity.UpdatedAt = DateTime.UtcNow;
+
+            preparedRepo.UpdateAsync(entity);
+            await unitOfWork.SaveChangesAsync();
+
+            var dto = PreparedQuestionMapper.ToDto(entity);
+
+            try
+            {
+                await pusher.PushPreparedQuestionStatusChangedAsync(entity.InterviewRoomId, dto);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to push PreparedQuestionStatusChanged (unmark) for {PreparedQuestionId}",
+                    preparedQuestionId);
+            }
+
+            return dto;
+        }
+    }
+}

--- a/Intervu.Application/UseCases/PreparedQuestion/UpdatePreparedQuestion.cs
+++ b/Intervu.Application/UseCases/PreparedQuestion/UpdatePreparedQuestion.cs
@@ -1,0 +1,71 @@
+using Intervu.Application.DTOs.PreparedQuestion;
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.UseCases.PreparedQuestion;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using Intervu.Domain.Repositories;
+using System;
+using System.Threading.Tasks;
+
+namespace Intervu.Application.UseCases.PreparedQuestion
+{
+    public class UpdatePreparedQuestion(IUnitOfWork unitOfWork) : IUpdatePreparedQuestion
+    {
+        public async Task<PreparedQuestionDto> ExecuteAsync(
+            Guid preparedQuestionId,
+            UpdatePreparedQuestionRequest request,
+            Guid userId)
+        {
+            if (request == null)
+            {
+                throw new BadRequestException("Request body is required");
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Title))
+            {
+                throw new BadRequestException("Title is required");
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Description))
+            {
+                throw new BadRequestException("Description is required");
+            }
+
+            var preparedRepo = unitOfWork.GetRepository<IPreparedQuestionRepository>();
+            var entity = await preparedRepo.GetByIdAsync(preparedQuestionId)
+                ?? throw new NotFoundException("Prepared question not found");
+
+            var roomRepo = unitOfWork.GetRepository<IInterviewRoomRepository>();
+            await PreparedQuestionAuthorization.EnsureRoomCoachAsync(roomRepo, entity.InterviewRoomId, userId);
+
+            entity.Title = request.Title.Trim();
+            entity.Description = request.Description;
+
+            if (!string.IsNullOrWhiteSpace(request.DisplayCategoryLabel))
+            {
+                entity.DisplayCategoryLabel = request.DisplayCategoryLabel.Trim();
+            }
+
+            if (entity.InteractionType == PreparedQuestionInteractionType.Coding)
+            {
+                entity.FunctionName = string.IsNullOrWhiteSpace(request.FunctionName)
+                    ? null
+                    : request.FunctionName.Trim();
+                entity.TestCases = PreparedQuestionMapper.NormalizeTestCasesForPersistence(request.TestCases);
+            }
+            else
+            {
+                // Keep non-coding rows clean of coding-only fields.
+                entity.FunctionName = null;
+                entity.TestCases = null;
+            }
+
+            entity.UpdatedAt = DateTime.UtcNow;
+
+            preparedRepo.UpdateAsync(entity);
+            await unitOfWork.SaveChangesAsync();
+
+            return PreparedQuestionMapper.ToDto(entity);
+        }
+    }
+}

--- a/Intervu.Domain/Entities/Constants/PreparedQuestionConstants.cs
+++ b/Intervu.Domain/Entities/Constants/PreparedQuestionConstants.cs
@@ -1,0 +1,19 @@
+namespace Intervu.Domain.Entities.Constants.PreparedQuestionConstants
+{
+    /// <summary>
+    /// Drives the in-room action button for a prepared question.
+    /// NonCoding -> "Mark as Asked" (no candidate broadcast).
+    /// Coding    -> "Send to Editor" (broadcasts ReceiveProblem to the candidate).
+    /// </summary>
+    public enum PreparedQuestionInteractionType
+    {
+        NonCoding = 1,
+        Coding = 2
+    }
+
+    public enum PreparedQuestionStatus
+    {
+        Pending = 1,
+        Asked = 2
+    }
+}

--- a/Intervu.Domain/Entities/InterviewRoom.cs
+++ b/Intervu.Domain/Entities/InterviewRoom.cs
@@ -173,6 +173,8 @@ namespace Intervu.Domain.Entities
 
         public ICollection<GeneratedQuestion> GeneratedQuestions { get; set; } = new List<GeneratedQuestion>();
 
+        public ICollection<PreparedQuestion> PreparedQuestions { get; set; } = new List<PreparedQuestion>();
+
         public bool IsAvailableForReschedule()
         {
             if (Status != InterviewRoomStatus.Scheduled) return false;

--- a/Intervu.Domain/Entities/PreparedQuestion.cs
+++ b/Intervu.Domain/Entities/PreparedQuestion.cs
@@ -1,0 +1,92 @@
+using Intervu.Domain.Abstractions.Entity;
+using Intervu.Domain.Entities.Constants.PreparedQuestionConstants;
+using System;
+
+namespace Intervu.Domain.Entities
+{
+    /// <summary>
+    /// A question the coach has prepared for a specific InterviewRoom ("session") prior
+    /// to (and usable during) the live interview. Distinct from:
+    ///   - Question:          the global question bank (authored globally).
+    ///   - GeneratedQuestion: AI-extracted / post-interview approval flow.
+    ///   - QuestionItem:      legacy JSONB stub on InterviewRoom.QuestionList.
+    /// </summary>
+    public class PreparedQuestion : EntityBase<Guid>
+    {
+        public Guid InterviewRoomId { get; set; }
+        public virtual InterviewRoom InterviewRoom { get; set; } = null!;
+
+        /// <summary>
+        /// Coach (user) who created this prepared question.
+        /// </summary>
+        public Guid CreatedBy { get; set; }
+
+        /// <summary>
+        /// When the question was imported from the question bank, this links back to
+        /// the source Question.Id. Null for fully custom-authored questions.
+        /// Snapshot semantics: edits to the bank row do NOT update this record.
+        /// </summary>
+        public Guid? SourceBankQuestionId { get; set; }
+
+        /// <summary>
+        /// Binary business switch:
+        ///   NonCoding -> Mark as Asked (no candidate broadcast)
+        ///   Coding    -> Send to Editor (broadcasts ReceiveProblem)
+        /// </summary>
+        public PreparedQuestionInteractionType InteractionType { get; set; }
+
+        /// <summary>
+        /// Free-form display label (e.g. "Behavioral", "Technical", "System Design",
+        /// "Process", "Coding"). Sourced from the bank or inferred on custom create.
+        /// Informational only; does NOT drive behavior.
+        /// </summary>
+        public string? DisplayCategoryLabel { get; set; }
+
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>Rich HTML (Quill output).</summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>Coding-only. e.g. "twoSum".</summary>
+        public string? FunctionName { get; set; }
+
+        /// <summary>
+        /// Coding-only. Identical shape to InterviewRoom.TestCases
+        /// (<c>[{ inputs: [{name, value}], expectedOutputs: [string] }]</c>) so we can
+        /// copy it straight into the room fields on Send to Editor.
+        /// JSON-serialized via EF fluent config.
+        /// </summary>
+        public object[]? TestCases { get; set; }
+
+        public PreparedQuestionStatus Status { get; set; } = PreparedQuestionStatus.Pending;
+
+        public DateTime? AskedAt { get; set; }
+
+        /// <summary>Ordering within the prepared list for this room (ascending).</summary>
+        public int SortOrder { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// A coding question is only "ready for editor" once the coach has provided
+        /// a function name AND at least one test case. Bank-imported coding questions
+        /// start incomplete and must be completed before Send to Editor is allowed.
+        /// </summary>
+        public bool IsReadyForEditor()
+        {
+            if (InteractionType != PreparedQuestionInteractionType.Coding)
+            {
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(FunctionName))
+            {
+                return false;
+            }
+
+            return TestCases != null && TestCases.Length > 0;
+        }
+    }
+}

--- a/Intervu.Domain/Repositories/IPreparedQuestionRepository.cs
+++ b/Intervu.Domain/Repositories/IPreparedQuestionRepository.cs
@@ -1,0 +1,18 @@
+using Intervu.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Intervu.Domain.Repositories
+{
+    public interface IPreparedQuestionRepository : IRepositoryBase<PreparedQuestion>
+    {
+        Task<List<PreparedQuestion>> GetByInterviewRoomIdAsync(Guid interviewRoomId);
+
+        Task<int> GetMaxSortOrderAsync(Guid interviewRoomId);
+
+        Task<PreparedQuestion?> FindByRoomAndBankQuestionAsync(Guid interviewRoomId, Guid bankQuestionId);
+
+        Task<List<PreparedQuestion>> GetByIdsAsync(Guid interviewRoomId, IEnumerable<Guid> ids);
+    }
+}

--- a/Intervu.Infrastructure/DependencyInjection.cs
+++ b/Intervu.Infrastructure/DependencyInjection.cs
@@ -94,6 +94,7 @@ namespace Intervu.Infrastructure
             services.AddScoped<IInterviewTypeRepository, InterviewTypeRepository>();
             services.AddScoped<IQuestionRepository, QuestionRepository>();
             services.AddScoped<IGeneratedQuestionRepository, GeneratedQuestionRepository>();
+            services.AddScoped<IPreparedQuestionRepository, PreparedQuestionRepository>();
             services.AddScoped<ICommentRepository, CommentRepository>();
             services.AddScoped<IInterviewExperienceRepository, InterviewExperienceRepository>();
             services.AddScoped<IInterviewReportRepository, InterviewReportRepository>();

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
@@ -42,6 +42,7 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
         public DbSet<InterviewReport> InterviewReports { get; set; }
         public DbSet<Question> Questions { get; set; }
         public DbSet<GeneratedQuestion> GeneratedQuestions { get; set; }
+        public DbSet<PreparedQuestion> PreparedQuestions { get; set; }
         public DbSet<Comment> Comments { get; set; }
         public DbSet<Tag> Tags { get; set; }
         public DbSet<QuestionTag> QuestionTags { get; set; }
@@ -603,6 +604,69 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
                  .HasForeignKey(x => x.InterviewRoomId)
                  .HasConstraintName("FK_GeneratedQuestions_InterviewRooms_InterviewRoomId")
                  .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            // PreparedQuestion
+            modelBuilder.Entity<PreparedQuestion>(b =>
+            {
+                b.ToTable("PreparedQuestions");
+                b.HasKey(x => x.Id);
+
+                b.Property(x => x.InteractionType).HasConversion<int>().IsRequired();
+                b.Property(x => x.Status).HasConversion<int>().IsRequired();
+
+                b.Property(x => x.Title).HasMaxLength(500).IsRequired();
+                b.Property(x => x.Description).HasColumnType("text").IsRequired();
+                b.Property(x => x.DisplayCategoryLabel).HasMaxLength(100).IsRequired(false);
+                b.Property(x => x.FunctionName).HasMaxLength(200).IsRequired(false);
+
+                b.Property(x => x.SortOrder).IsRequired();
+                b.Property(x => x.CreatedAt).IsRequired();
+                b.Property(x => x.UpdatedAt).IsRequired();
+                b.Property(x => x.AskedAt).IsRequired(false);
+                b.Property(x => x.SourceBankQuestionId).IsRequired(false);
+
+                // Reuse the same JSON conversion pattern used by InterviewRoom.TestCases
+                // so the shape { inputs:[{name,value}], expectedOutputs:[string] } lines up
+                // with the SendProblem hub contract and can be copied without transformation.
+                var pqJsonOptions = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    WriteIndented = false
+                };
+
+                var testCasesComparer = new Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer<object[]>(
+                    (c1, c2) => JsonSerializer.Serialize(c1, pqJsonOptions) == JsonSerializer.Serialize(c2, pqJsonOptions),
+                    c => c == null ? 0 : JsonSerializer.Serialize(c, pqJsonOptions).GetHashCode(),
+                    c => JsonSerializer.Deserialize<object[]>(JsonSerializer.Serialize(c, pqJsonOptions), pqJsonOptions)!);
+
+                b.Property(x => x.TestCases)
+                    .HasColumnName("TestCases")
+                    .HasConversion(
+                        v => v == null ? null : JsonSerializer.Serialize(v, pqJsonOptions),
+                        v => v == null ? null : JsonSerializer.Deserialize<object[]>(v, pqJsonOptions))
+                    .HasColumnType("jsonb")
+                    .IsRequired(false)
+                    .Metadata.SetValueComparer(testCasesComparer);
+
+                b.HasOne(x => x.InterviewRoom)
+                 .WithMany(r => r.PreparedQuestions)
+                 .HasForeignKey(x => x.InterviewRoomId)
+                 .HasConstraintName("FK_PreparedQuestions_InterviewRooms_InterviewRoomId")
+                 .OnDelete(DeleteBehavior.Cascade);
+
+                b.HasOne<Question>()
+                 .WithMany()
+                 .HasForeignKey(x => x.SourceBankQuestionId)
+                 .HasConstraintName("FK_PreparedQuestions_Questions_SourceBankQuestionId")
+                 .IsRequired(false)
+                 .OnDelete(DeleteBehavior.SetNull);
+
+                b.HasIndex(x => new { x.InterviewRoomId, x.SortOrder })
+                 .HasDatabaseName("IX_PreparedQuestions_InterviewRoomId_SortOrder");
+
+                b.HasIndex(x => x.SourceBankQuestionId)
+                 .HasDatabaseName("IX_PreparedQuestions_SourceBankQuestionId");
             });
 
             // Feedback

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260421140250_AddPreparedQuestions.Designer.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260421140250_AddPreparedQuestions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intervu.Infrastructure.Persistence.PostgreSQL.DataContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Intervu.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(IntervuPostgreDbContext))]
-    partial class IntervuPostgreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421140250_AddPreparedQuestions")]
+    partial class AddPreparedQuestions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260421140250_AddPreparedQuestions.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/Migrations/20260421140250_AddPreparedQuestions.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intervu.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPreparedQuestions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PreparedQuestions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    InterviewRoomId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceBankQuestionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InteractionType = table.Column<int>(type: "integer", nullable: false),
+                    DisplayCategoryLabel = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    FunctionName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    TestCases = table.Column<string>(type: "jsonb", nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    AskedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PreparedQuestions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PreparedQuestions_InterviewRooms_InterviewRoomId",
+                        column: x => x.InterviewRoomId,
+                        principalTable: "InterviewRooms",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PreparedQuestions_Questions_SourceBankQuestionId",
+                        column: x => x.SourceBankQuestionId,
+                        principalTable: "Questions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PreparedQuestions_InterviewRoomId_SortOrder",
+                table: "PreparedQuestions",
+                columns: new[] { "InterviewRoomId", "SortOrder" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PreparedQuestions_SourceBankQuestionId",
+                table: "PreparedQuestions",
+                column: "SourceBankQuestionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PreparedQuestions");
+        }
+    }
+}

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/PreparedQuestionRepository.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/PreparedQuestionRepository.cs
@@ -1,0 +1,59 @@
+using Intervu.Domain.Entities;
+using Intervu.Domain.Repositories;
+using Intervu.Infrastructure.Persistence.PostgreSQL.DataContext;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Intervu.Infrastructure.Persistence.PostgreSQL
+{
+    public class PreparedQuestionRepository(IntervuPostgreDbContext context)
+        : RepositoryBase<PreparedQuestion>(context), IPreparedQuestionRepository
+    {
+        public async Task<List<PreparedQuestion>> GetByInterviewRoomIdAsync(Guid interviewRoomId)
+        {
+            return await _context.PreparedQuestions
+                .Where(q => q.InterviewRoomId == interviewRoomId)
+                .OrderBy(q => q.SortOrder)
+                .ThenBy(q => q.CreatedAt)
+                .ToListAsync();
+        }
+
+        public async Task<int> GetMaxSortOrderAsync(Guid interviewRoomId)
+        {
+            var hasAny = await _context.PreparedQuestions
+                .AnyAsync(q => q.InterviewRoomId == interviewRoomId);
+
+            if (!hasAny)
+            {
+                return -1;
+            }
+
+            return await _context.PreparedQuestions
+                .Where(q => q.InterviewRoomId == interviewRoomId)
+                .MaxAsync(q => q.SortOrder);
+        }
+
+        public async Task<PreparedQuestion?> FindByRoomAndBankQuestionAsync(Guid interviewRoomId, Guid bankQuestionId)
+        {
+            return await _context.PreparedQuestions
+                .FirstOrDefaultAsync(q => q.InterviewRoomId == interviewRoomId
+                    && q.SourceBankQuestionId == bankQuestionId);
+        }
+
+        public async Task<List<PreparedQuestion>> GetByIdsAsync(Guid interviewRoomId, IEnumerable<Guid> ids)
+        {
+            var idSet = ids?.ToHashSet() ?? new HashSet<Guid>();
+            if (idSet.Count == 0)
+            {
+                return new List<PreparedQuestion>();
+            }
+
+            return await _context.PreparedQuestions
+                .Where(q => q.InterviewRoomId == interviewRoomId && idSet.Contains(q.Id))
+                .ToListAsync();
+        }
+    }
+}


### PR DESCRIPTION
- Created migration to add PreparedQuestions table with necessary fields and constraints.
- Updated DbContext model snapshot to include PreparedQuestions entity configuration.
- Implemented PreparedQuestionRepository with methods to retrieve prepared questions by interview room ID, get max sort order, find by room and bank question, and get by IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comprehensive prepared questions management: Create, update, delete, and reorder questions for interview rooms
  * Import questions from the question bank
  * Mark/unmark questions as asked during interviews
  * Send coding questions to editor with automatic code generation
  * Real-time status updates for prepared questions across all interview participants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->