### PR TITLE
Implement blocking mechanism for coach availability blockblock instead of hard delete

### DIFF
--- a/Intervu.API/Controllers/v1/CoachAvailability/AvailabilitiesController.cs
+++ b/Intervu.API/Controllers/v1/CoachAvailability/AvailabilitiesController.cs
@@ -14,6 +14,7 @@ namespace Intervu.API.Controllers.v1.CoachAvailability
         private readonly IGetCoachAvailabilities _getCoachAvailabilities;
         private readonly IGetCoachFreeSlots _getCoachFreeSlots;
         private readonly ICreateCoachAvailability _createCoachAvailability;
+        private readonly IBlockCoachAvailabilityTime _blockCoachAvailabilityTime;
         private readonly IDeleteCoachAvailability _deleteCoachAvailability;
         private readonly IUpdateCoachAvailability _updateCoachAvailability;
 
@@ -21,12 +22,14 @@ namespace Intervu.API.Controllers.v1.CoachAvailability
             IGetCoachAvailabilities getCoachAvailabilities,
             IGetCoachFreeSlots getCoachFreeSlots,
             ICreateCoachAvailability createCoachAvailability,
+            IBlockCoachAvailabilityTime blockCoachAvailabilityTime,
             IDeleteCoachAvailability deleteCoachAvailability,
             IUpdateCoachAvailability updateCoachAvailability)
         {
             _getCoachAvailabilities = getCoachAvailabilities;
             _getCoachFreeSlots = getCoachFreeSlots;
             _createCoachAvailability = createCoachAvailability;
+            _blockCoachAvailabilityTime = blockCoachAvailabilityTime;
             _deleteCoachAvailability = deleteCoachAvailability;
             _updateCoachAvailability = updateCoachAvailability;
         }
@@ -79,6 +82,27 @@ namespace Intervu.API.Controllers.v1.CoachAvailability
             {
                 await _deleteCoachAvailability.ExecuteAsync(availabilityId);
                 return Ok(new { success = true, message = "Deleted" });
+            }
+            catch (System.Exception ex)
+            {
+                return BadRequest(new { success = false, message = ex.Message });
+            }
+        }
+
+        [HttpPost("{availabilityId}/blocked-times")]
+        public async Task<IActionResult> BlockCoachAvailabilityTime(
+            Guid availabilityId,
+            [FromBody] BlockCoachAvailabilityTimeDto request)
+        {
+            try
+            {
+                await _blockCoachAvailabilityTime.ExecuteAsync(
+                    availabilityId,
+                    request.StartTime,
+                    request.EndTime,
+                    request.Reason);
+
+                return Ok(new { success = true, message = "Blocked time added" });
             }
             catch (System.Exception ex)
             {

--- a/Intervu.Application/DTOs/Availability/BlockCoachAvailabilityTimeDto.cs
+++ b/Intervu.Application/DTOs/Availability/BlockCoachAvailabilityTimeDto.cs
@@ -1,0 +1,11 @@
+namespace Intervu.Application.DTOs.Availability
+{
+    public class BlockCoachAvailabilityTimeDto
+    {
+        public DateTime StartTime { get; set; }
+
+        public DateTime EndTime { get; set; }
+
+        public string? Reason { get; set; }
+    }
+}

--- a/Intervu.Application/DependencyInjection.cs
+++ b/Intervu.Application/DependencyInjection.cs
@@ -143,6 +143,7 @@ namespace Intervu.Application
             services.AddScoped<IGetCoachAvailabilities, GetCoachAvailabilities>();
             services.AddScoped<IGetCoachFreeSlots, GetCoachFreeSlots>();
             services.AddScoped<ICreateCoachAvailability, CreateCoachAvailability>();
+            services.AddScoped<IBlockCoachAvailabilityTime, BlockCoachAvailabilityTime>();
             services.AddScoped<IDeleteCoachAvailability, DeleteCoachAvailability>();
             services.AddScoped<IUpdateAvailabilityStatus, UpdateAvailabilityStatus>();
             services.AddScoped<IUpdateCoachAvailability, UpdateCoachAvailability>();

--- a/Intervu.Application/Interfaces/UseCases/Availability/IBlockCoachAvailabilityTime.cs
+++ b/Intervu.Application/Interfaces/UseCases/Availability/IBlockCoachAvailabilityTime.cs
@@ -1,0 +1,7 @@
+namespace Intervu.Application.Interfaces.UseCases.Availability
+{
+    public interface IBlockCoachAvailabilityTime
+    {
+        Task ExecuteAsync(Guid availabilityId, DateTime startTime, DateTime endTime, string? reason);
+    }
+}

--- a/Intervu.Application/UseCases/Availability/BlockCoachAvailabilityTime.cs
+++ b/Intervu.Application/UseCases/Availability/BlockCoachAvailabilityTime.cs
@@ -1,0 +1,75 @@
+using Intervu.Application.Exceptions;
+using Intervu.Application.Interfaces.UseCases.Availability;
+using Intervu.Domain.Abstractions.Entity.Interfaces;
+using Intervu.Domain.Entities;
+using Intervu.Domain.Entities.Constants;
+using Intervu.Domain.Repositories;
+
+namespace Intervu.Application.UseCases.Availability
+{
+    public class BlockCoachAvailabilityTime : IBlockCoachAvailabilityTime
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ICoachAvailabilitiesRepository _availabilityRepo;
+        private readonly ITransactionRepository _transactionRepo;
+        private readonly IBookingRequestRepository _bookingRequestRepo;
+
+        public BlockCoachAvailabilityTime(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+            _availabilityRepo = _unitOfWork.GetRepository<ICoachAvailabilitiesRepository>();
+            _transactionRepo = _unitOfWork.GetRepository<ITransactionRepository>();
+            _bookingRequestRepo = _unitOfWork.GetRepository<IBookingRequestRepository>();
+        }
+
+        public async Task ExecuteAsync(Guid availabilityId, DateTime startTime, DateTime endTime, string? reason)
+        {
+            if (availabilityId == Guid.Empty)
+                throw new BadRequestException("Availability ID must be provided.");
+
+            if (endTime <= startTime)
+                throw new BadRequestException("End time must be greater than start time.");
+
+            var availability = await _availabilityRepo.GetByIdAsync(availabilityId)
+                ?? throw new NotFoundException($"Coach availability '{availabilityId}' was not found.");
+
+            if (availability.Status != CoachAvailabilityStatus.Available)
+                throw new BadRequestException("Only available slots can be partially blocked.");
+
+            if (startTime < availability.StartTime || endTime > availability.EndTime)
+                throw new BadRequestException("Blocked range must be inside the original availability slot.");
+
+            availability.BlockedTimes ??= [];
+
+            if (availability.BlockedTimes.Any(bt => bt.StartTime < endTime && bt.EndTime > startTime))
+                throw new BadRequestException("Blocked range overlaps an existing blocked interval.");
+
+            var activeTransactions = await _transactionRepo
+                .GetActiveBookingsByCoachAsync(availability.CoachId, startTime, endTime);
+
+            var overlapsFlowABooking = activeTransactions.Any(t =>
+                t.BookedStartTime.HasValue
+                && t.BookedDurationMinutes.HasValue
+                && t.BookedStartTime.Value < endTime
+                && t.BookedStartTime.Value.AddMinutes(t.BookedDurationMinutes.Value) > startTime);
+
+            if (overlapsFlowABooking)
+                throw new BadRequestException("Cannot block this time range because it overlaps an active booking.");
+
+            var activeRounds = await _bookingRequestRepo
+                .GetActiveRoundsByCoachAsync(availability.CoachId, startTime, endTime);
+
+            if (activeRounds.Any())
+                throw new BadRequestException("Cannot block this time range because it overlaps an active booking request.");
+
+            availability.BlockedTimes.Add(new BlockedTime
+            {
+                StartTime = startTime,
+                EndTime = endTime,
+                Reason = reason
+            });
+
+            await _unitOfWork.SaveChangesAsync();
+        }
+    }
+}

--- a/Intervu.Application/UseCases/Availability/GetCoachFreeSlots.cs
+++ b/Intervu.Application/UseCases/Availability/GetCoachFreeSlots.cs
@@ -50,7 +50,13 @@ namespace Intervu.Application.UseCases.Availability
             var activeRounds = await _bookingRequestRepo
                 .GetActiveRoundsByCoachAsync(coachId, rangeStart, rangeEnd);
 
-            // Merge both sources into unified (Start, End) intervals
+            // Extract blocked sub-ranges from availability windows
+            var blockedIntervals = availabilities
+                .SelectMany(a => a.BlockedTimes ?? [])
+                .Where(bt => bt.EndTime > bt.StartTime)
+                .Select(bt => (Start: bt.StartTime, End: bt.EndTime));
+
+            // Merge all sources into unified (Start, End) intervals
             var allBookedIntervals = activeTransactions
                 .Where(t => t.BookedStartTime.HasValue && t.BookedDurationMinutes.HasValue)
                 .Select(t => (
@@ -58,6 +64,7 @@ namespace Intervu.Application.UseCases.Availability
                     End: t.BookedStartTime!.Value.AddMinutes(t.BookedDurationMinutes!.Value)
                 ))
                 .Concat(activeRounds)
+                .Concat(blockedIntervals)
                 .ToList();
 
             // 4. Compute free slots using the subtraction algorithm

--- a/Intervu.Domain/Entities/BlockedTime.cs
+++ b/Intervu.Domain/Entities/BlockedTime.cs
@@ -1,0 +1,14 @@
+namespace Intervu.Domain.Entities
+{
+    /// <summary>
+    /// Represents a blocked sub-range inside an availability window.
+    /// </summary>
+    public record BlockedTime
+    {
+        public DateTime StartTime { get; set; }
+
+        public DateTime EndTime { get; set; }
+
+        public string? Reason { get; set; }
+    }
+}

--- a/Intervu.Domain/Entities/CoachAvailability.cs
+++ b/Intervu.Domain/Entities/CoachAvailability.cs
@@ -21,6 +21,8 @@ namespace Intervu.Domain.Entities
 
         public CoachAvailabilityStatus Status { get; set; }
 
+        public List<BlockedTime> BlockedTimes { get; set; } = new();
+
         // Navigation
         public CoachProfile? CoachProfile { get; set; }
 

--- a/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/DataContext/IntervuPostgreDbContext.cs
@@ -247,6 +247,14 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL.DataContext
                 b.Property(x => x.EndTime).IsRequired();
                 b.Property(x => x.Status).IsRequired();
 
+                b.OwnsMany(x => x.BlockedTimes, blocked =>
+                {
+                    blocked.ToJson();
+                    blocked.Property(x => x.StartTime).IsRequired();
+                    blocked.Property(x => x.EndTime).IsRequired();
+                    blocked.Property(x => x.Reason).HasMaxLength(500);
+                });
+
                 b.HasOne(x => x.CoachProfile)
                 .WithMany()
                 .HasForeignKey(x => x.CoachId)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# INTERVU - Guidelines & Conventions
 
-Welcome to the Intervu project! This document provides general guidelines and conventions to ensure code quality and consistency throughout the development process.
+Welcome to the Intervu project! This document provides general guidelines and conventions to ensure code quality and consistency throughout the development process. 
 
 ## Quick Links (Tabs)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coaches can now block specific time periods within their availability calendar to prevent bookings during those intervals. Blocked times are automatically excluded from available slots shown to clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->