### PR TITLE
ref: Order feedback: blank ratings first, by schedule

### DIFF
--- a/Intervu.Infrastructure/Persistence/PostgreSQL/FeedbackRepository.cs
+++ b/Intervu.Infrastructure/Persistence/PostgreSQL/FeedbackRepository.cs
@@ -27,6 +27,8 @@ namespace Intervu.Infrastructure.Persistence.PostgreSQL
             var totalItems = await query.CountAsync();
 
             var items = await query
+            .OrderByDescending(f => f.Rating == 0 && (f.Comments == null || f.Comments == ""))
+            .ThenByDescending(f => f.InterviewRoom != null ? f.InterviewRoom.ScheduledTime : null)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
                 .ToListAsync();


### PR DESCRIPTION
Add ordering to the feedback query to prioritize entries with rating == 0 and empty/null comments, then sort by InterviewRoom.ScheduledTime descending. This ensures incomplete/blank feedback appears first and results are consistently ordered before pagination (Skip/Take).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated feedback ordering to prioritize unrated entries and sort results by interview date in descending order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->