### PR TITLE
ref(Room Report): Add Transcript to RoomReport DTO

### DIFF
--- a/Intervu.Application/DTOs/InterviewRoom/RoomReportDtos.cs
+++ b/Intervu.Application/DTOs/InterviewRoom/RoomReportDtos.cs
@@ -77,6 +77,7 @@ namespace Intervu.Application.DTOs.InterviewRoom
         public string? ExpectTo { get; set; }
         public InterviewReportStatus Status { get; set; }
         public DateTime CreatedAt { get; set; }
+        public string? Transcript { get; set; }
         public RoomReportBookingContextDto BookingContext { get; set; } = new();
         public RoomReportFinancialStatusDto FinancialStatus { get; set; } = new();
     }

--- a/Intervu.Application/UseCases/InterviewRoom/GetInterviewReportDetail.cs
+++ b/Intervu.Application/UseCases/InterviewRoom/GetInterviewReportDetail.cs
@@ -51,6 +51,7 @@ namespace Intervu.Application.UseCases.InterviewRoom
                 ExpectTo = report.ExpectTo,
                 Status = report.Status,
                 CreatedAt = report.CreatedAt,
+                Transcript = room.Transcript,
                 BookingContext = new RoomReportBookingContextDto
                 {
                     CoachName = coach?.FullName,


### PR DESCRIPTION
Expose the interview transcript in room report responses by adding a nullable Transcript property to RoomReportDto and populating it in GetInterviewReportDetail (mapped from room.Transcript). This ensures the report payload includes transcript data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interview room reports now include transcript information for easier reference and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->