### PR TITLE
ref(GeneratedQuestions): Add ExperienceLevel to DTOs & update enums

### DIFF
--- a/Intervu.Application/DTOs/GeneratedQuestion/GeneratedQuestionDtos.cs
+++ b/Intervu.Application/DTOs/GeneratedQuestion/GeneratedQuestionDtos.cs
@@ -13,6 +13,7 @@ namespace Intervu.Application.DTOs.GeneratedQuestion
         public string Title { get; set; } = string.Empty;
         public string Content { get; set; } = string.Empty;
         public GeneratedQuestionStatus Status { get; set; }
+        public ExperienceLevel Level { get; set; }
         public List<string> Tags { get; set; } = new();
     }
 
@@ -24,6 +25,8 @@ namespace Intervu.Application.DTOs.GeneratedQuestion
         public string Title { get; set; } = string.Empty;
 
         public Guid InterviewRoomId { get; set; }
+
+        public ExperienceLevel Level { get; set; } = ExperienceLevel.Intern;
 
         public List<string> Tags { get; set; } = new();
     }

--- a/Intervu.Application/Services/RoomManagerService.cs
+++ b/Intervu.Application/Services/RoomManagerService.cs
@@ -72,7 +72,7 @@ namespace Intervu.Application.Services
         private readonly ConcurrentDictionary<string, RoomState> _roomStates = new();
         private readonly ConcurrentDictionary<string, Timer> _periodicSaveTimers = new();
         private readonly ConcurrentDictionary<string, Timer> _roomTimers = new();
-        private readonly TimeSpan _roomExpiryTime = TimeSpan.FromSeconds(60);
+        private readonly TimeSpan _roomExpiryTime = TimeSpan.FromSeconds(20);
         private readonly TimeSpan _periodicSaveInterval = TimeSpan.FromSeconds(30);
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly double value;

--- a/Intervu.Application/UseCases/GeneratedQuestion/ApproveGeneratedQuestion.cs
+++ b/Intervu.Application/UseCases/GeneratedQuestion/ApproveGeneratedQuestion.cs
@@ -1,4 +1,5 @@
 using Intervu.Application.DTOs.GeneratedQuestion;
+using Intervu.Application.Exceptions;
 using Intervu.Application.Interfaces.UseCases.Audit;
 using Intervu.Application.Interfaces.UseCases.GeneratedQuestion;
 using Intervu.Domain.Abstractions.Entity.Interfaces;
@@ -24,11 +25,11 @@ namespace Intervu.Application.UseCases.GeneratedQuestion
             var tagRepo = unitOfWork.GetRepository<ITagRepository>();
 
             var generated = await generatedRepo.GetByIdAsync(generatedQuestionId)
-                ?? throw new Exception("Generated question not found");
+                ?? throw new NotFoundException("Generated question not found");
 
             if (generated.Status != GeneratedQuestionStatus.PendingReview)
             {
-                throw new Exception("Generated question is already reviewed");
+                throw new ConflictException("Generated question is already reviewed");
             }
 
             // Prepare Audit Log data before modification
@@ -39,12 +40,14 @@ namespace Intervu.Application.UseCases.GeneratedQuestion
                 {
                     Title = generated.Title,
                     Content = generated.Content,
+                    Level = Domain.Entities.Constants.QuestionConstants.ExperienceLevel.Intern,
                     TagIds = generated.TagIds
                 },
                 Approved = new
                 {
                     Title = request.Title?.Trim() ?? generated.Title,
                     Content = request.Content?.Trim() ?? generated.Content,
+                    Level = request.Level,
                     TagIds = request.TagIds,
                     Tags = request.Tags
                 }
@@ -59,8 +62,8 @@ namespace Intervu.Application.UseCases.GeneratedQuestion
                 Content = string.IsNullOrWhiteSpace(request.Content) ? generated.Content : request.Content.Trim(),
                 InterviewExperienceId = request.InterviewExperienceId,
                 Level = request.Level,
-                Round = request.Round,
-                Category = request.Category,
+                Round = Domain.Entities.Constants.QuestionConstants.InterviewRound.Other,
+                Category = Domain.Entities.Constants.QuestionConstants.QuestionCategory.Other,
                 Status = Domain.Entities.Constants.QuestionConstants.QuestionStatus.Pending,
                 CreatedBy = reviewerUserId,
                 CreatedAt = now,

--- a/Intervu.Application/UseCases/GeneratedQuestion/CreateGeneratedQuestion.cs
+++ b/Intervu.Application/UseCases/GeneratedQuestion/CreateGeneratedQuestion.cs
@@ -22,7 +22,7 @@ namespace Intervu.Application.UseCases.GeneratedQuestion
                 InterviewRoomId = request.InterviewRoomId,
                 Title = request.Title?.Trim() ?? string.Empty,
                 Content = request.Content.Trim(),
-                Status = GeneratedQuestionStatus.PendingReview
+                Status = GeneratedQuestionStatus.PendingReview,
             };
 
             if (request.Tags != null && request.Tags.Any())

--- a/Intervu.Domain/Entities/Constants/QuestionConstants.cs
+++ b/Intervu.Domain/Entities/Constants/QuestionConstants.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Intervu.Domain.Entities.Constants.QuestionConstants
 {
     public enum QuestionStatus
@@ -17,29 +19,49 @@ namespace Intervu.Domain.Entities.Constants.QuestionConstants
 
     public enum ResolutionAction
     {
+        [Description("No Action")]
         NoAction = 0,
+        [Description("Deactivate Question")]
         DeactivateQuestion = 1,
+        [Description("Edit Question")]
         EditQuestion = 2
     }
 
     public enum Role
     {
+        [Description("Product Manager")]
         ProductManager = 1,
+        [Description("Software Engineer")]
         SoftwareEngineer = 2,
+        [Description("Data Engineer")]
         DataEngineer = 3,
+        [Description("Data Scientist")]
         DataScientist = 4,
+        [Description("Technical Program Manager")]
         TechnicalProgramManager = 5,
+        [Description("Backend Engineer")]
         BackendEngineer = 6,
+        [Description("Frontend Engineer")]
         FrontendEngineer = 7,
+        [Description("Full Stack Engineer")]
         FullStackEngineer = 8,
+        [Description("Mobile Engineer")]
         MobileEngineer = 9,
+        [Description("DevOps Engineer")]
         DevOpsEngineer = 10,
+        [Description("QA Engineer")]
         QAEngineer = 11,
+        [Description("Machine Learning Engineer")]
         MachineLearningEngineer = 12,
+        [Description("Security Engineer")]
         SecurityEngineer = 13,
+        [Description("Cloud Engineer")]
         CloudEngineer = 14,
+        [Description("UI/UX Designer")]
         UIUXDesigner = 15,
+        [Description("Business Analyst")]
         BusinessAnalyst = 16,
+        [Description("Solution Architect")]
         SolutionArchitect = 17
     }
 
@@ -47,7 +69,9 @@ namespace Intervu.Domain.Entities.Constants.QuestionConstants
     {
         Behavioral = 1,
         Technical = 2,
+        [Description("System Design")]
         SystemDesign = 3,
+        [Description("Case Study")]
         CaseStudy = 4,
         Other = 5,
         Coding = 6,
@@ -55,8 +79,10 @@ namespace Intervu.Domain.Entities.Constants.QuestionConstants
         Networking = 8,
         OOP = 9,
         Algorithms = 10,
+        [Description("Data Structures")]
         DataStructures = 11,
         Concurrency = 12,
+        [Description("Distributed Systems")]
         DistributedSystems = 13,
         Cloud = 14,
         DevOps = 15
@@ -83,16 +109,26 @@ namespace Intervu.Domain.Entities.Constants.QuestionConstants
 
     public enum InterviewRound
     {
+        [Description("Phone Screen")]
         PhoneScreen = 1,
+        [Description("Technical Screen")]
         TechnicalScreen = 2,
+        [Description("Take Home")]
         TakeHome = 3,
+        [Description("Onsite / Final Round")]
         OnsiteFinalRound = 4,
         Other = 5,
+        [Description("HR Round")]
         HRRound = 6,
+        [Description("Coding Challenge")]
         CodingChallenge = 7,
+        [Description("Live Coding")]
         LiveCoding = 8,
+        [Description("System Design Round")]
         SystemDesignRound = 9,
+        [Description("Behavioral Round")]
         BehavioralRound = 10,
+        [Description("Managerial Round")]
         ManagerialRound = 11
     }
 
@@ -100,7 +136,9 @@ namespace Intervu.Domain.Entities.Constants.QuestionConstants
     {
         Behavioral = 1,
         Technical = 2,
+        [Description("System Design")]
         SystemDesign = 3,
+        [Description("Case Study")]
         CaseStudy = 4,
         Other = 5,
         Coding = 6,
@@ -108,8 +146,10 @@ namespace Intervu.Domain.Entities.Constants.QuestionConstants
         Networking = 8,
         OOP = 9,
         Algorithms = 10,
+        [Description("Data Structures")]
         DataStructures = 11,
         Concurrency = 12,
+        [Description("Distributed Systems")]
         DistributedSystems = 13,
         Cloud = 14,
         DevOps = 15


### PR DESCRIPTION
Add an ExperienceLevel (Level) property to GeneratedQuestion DTOs with a default of Intern and wire Level handling into ApproveGeneratedQuestion. Replace generic Exceptions with NotFoundException/ConflictException and set default Round/Category to Other when approving. Reduce RoomManagerService room expiry from 60s to 20s. Add Description attributes and additional enum metadata in QuestionConstants to improve UI-friendly labels and enum semantics. Small formatting fixes (trailing comma) included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Questions now include experience level tracking with Intern as the default level.

* **Improvements**
  * Enhanced error handling for question approval workflows.
  * Reduced room cleanup duration for faster resource management.

* **Enhancements**
  * Added descriptive labels for question types, roles, interview rounds, and categories for improved UI presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->